### PR TITLE
Release/1.0.0

### DIFF
--- a/info.json
+++ b/info.json
@@ -39,7 +39,8 @@
         "globalVariables": [],
         "rules": [
             "Slack > Notify For External Manual Input",
-            "Slack > Send Manual Input Link To Slack"
+            "Slack > Send Manual Input Link To Slack",
+            "Slack > Notify On Playbook Failure"
         ],
         "ruleChannels": [
             "Slack",

--- a/playbooks/02 - Use Case - FortiSOAR for Slack/Create Indicator.json
+++ b/playbooks/02 - Use Case - FortiSOAR for Slack/Create Indicator.json
@@ -321,7 +321,7 @@
       },
       {
         "@type": "WorkflowStep",
-        "name": "Temp Variable",
+        "name": "Placeholder",
         "description": null,
         "arguments": [],
         "status": null,
@@ -362,7 +362,7 @@
               "option": "Yes",
               "step_iri": "/api/3/workflow_steps/b89256b7-f00b-4234-bc95-e45dfdbd1896",
               "condition": "{{ ((vars.indicator_val | string).strip() | length) > 0 }}",
-              "step_name": "Temp Variable"
+              "step_name": "Placeholder"
             }
           ]
         },

--- a/playbooks/02 - Use Case - FortiSOAR for Slack/Create Indicator.json
+++ b/playbooks/02 - Use Case - FortiSOAR for Slack/Create Indicator.json
@@ -10,520 +10,550 @@
     "singleRecordExecution": false,
     "remoteExecutableFlag": false,
     "parameters": [
-        "indicatorVal"
+      "indicatorVal"
     ],
     "synchronous": false,
-    "collection": "\/api\/3\/workflow_collections\/49291f43-e8a1-4f63-80b5-d88e05044a4a",
+    "lastModifyDate": 1673521224,
+    "collection": "/api/3/workflow_collections/49291f43-e8a1-4f63-80b5-d88e05044a4a",
     "versions": [],
-    "triggerStep": "\/api\/3\/workflow_steps\/978b6805-b07f-4876-b9aa-546ff464c163",
+    "triggerStep": "/api/3/workflow_steps/978b6805-b07f-4876-b9aa-546ff464c163",
     "steps": [
-        {
-            "@type": "WorkflowStep",
-            "name": "Set Indicator",
-            "description": null,
-            "arguments": {
-                "indicator_val": "{{vars.steps.Manual_Input_Form.input.indicator}}"
-            },
-            "status": null,
-            "top": "580",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-            "group": null,
-            "uuid": "091bfa45-902c-4289-8813-0808f26a1ff8"
+      {
+        "@type": "WorkflowStep",
+        "name": "Set Indicator",
+        "description": null,
+        "arguments": {
+          "indicator_val": "{{vars.steps.Manual_Input_Form.input.indicator}}"
         },
-        {
-            "@type": "WorkflowStep",
-            "name": "Is Valid Indicator",
-            "description": null,
-            "arguments": {
-                "conditions": [
-                    {
-                        "option": "Invalid",
-                        "default": true,
-                        "step_iri": "\/api\/3\/workflow_steps\/59dd8052-c04f-44b1-a365-9c526e612754",
-                        "step_name": "Incorrect Parameters"
-                    },
-                    {
-                        "option": "Valid",
-                        "step_iri": "\/api\/3\/workflow_steps\/35b8cf2b-8b74-4e2b-9d20-fc0e588f5689",
-                        "condition": "{{ vars.steps.Extract_Artifact.data.results| length > 0 }}",
-                        "step_name": "Create Indicator"
-                    }
-                ]
+        "status": null,
+        "top": "570",
+        "left": "908",
+        "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+        "group": null,
+        "uuid": "091bfa45-902c-4289-8813-0808f26a1ff8"
+      },
+      {
+        "@type": "WorkflowStep",
+        "name": "Is Valid Indicator",
+        "description": null,
+        "arguments": {
+          "conditions": [
+            {
+              "option": "Invalid",
+              "default": true,
+              "step_iri": "/api/3/workflow_steps/59dd8052-c04f-44b1-a365-9c526e612754",
+              "step_name": "Incorrect Parameters"
             },
-            "status": null,
-            "top": "975",
-            "left": "1010",
-            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-            "group": null,
-            "uuid": "0e715216-3a72-444a-bfde-2f418f60d505"
+            {
+              "option": "Valid",
+              "step_iri": "/api/3/workflow_steps/35b8cf2b-8b74-4e2b-9d20-fc0e588f5689",
+              "condition": "{{ vars.steps.Extract_Artifact.data.results| length > 0 }}",
+              "step_name": "Create Indicator"
+            }
+          ]
         },
-        {
-            "@type": "WorkflowStep",
-            "name": "Check for blank form submission",
-            "description": null,
-            "arguments": {
-                "conditions": [
-                    {
-                        "option": "Params Passed",
-                        "step_iri": "\/api\/3\/workflow_steps\/53cdd8f7-068e-4a86-859e-1652ee2e44a3",
-                        "condition": "{{ (vars.indicator_val != None) }}",
-                        "step_name": "Extract Artifact"
-                    },
-                    {
-                        "option": "Params Blank",
-                        "default": true,
-                        "step_iri": "\/api\/3\/workflow_steps\/184093ee-68a9-4f15-8afa-019e99658747",
-                        "step_name": "Manual Input Invalid Indicator"
-                    }
-                ]
+        "status": null,
+        "top": "975",
+        "left": "300",
+        "stepType": "/api/3/workflow_step_types/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+        "group": null,
+        "uuid": "0e715216-3a72-444a-bfde-2f418f60d505"
+      },
+      {
+        "@type": "WorkflowStep",
+        "name": "Check for blank form submission",
+        "description": null,
+        "arguments": {
+          "conditions": [
+            {
+              "option": "Params Passed",
+              "step_iri": "/api/3/workflow_steps/53cdd8f7-068e-4a86-859e-1652ee2e44a3",
+              "condition": "{{ (vars.indicator_val != None) }}",
+              "step_name": "Extract Artifact"
             },
-            "status": null,
-            "top": "705",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-            "group": null,
-            "uuid": "117e01d2-5604-4f51-b800-6affa0de51fe"
+            {
+              "option": "Params Blank",
+              "default": true,
+              "step_iri": "/api/3/workflow_steps/184093ee-68a9-4f15-8afa-019e99658747",
+              "step_name": "Manual Input Invalid Indicator"
+            }
+          ]
         },
-        {
-            "@type": "WorkflowStep",
-            "name": "Manual Input Invalid Indicator",
-            "description": null,
-            "arguments": {
-                "bot_response": "The indicator parameters provided were incorrect"
-            },
-            "status": null,
-            "top": "1245",
-            "left": "125",
-            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-            "group": null,
-            "uuid": "184093ee-68a9-4f15-8afa-019e99658747"
+        "status": null,
+        "top": "700",
+        "left": "480",
+        "stepType": "/api/3/workflow_step_types/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+        "group": null,
+        "uuid": "117e01d2-5604-4f51-b800-6affa0de51fe"
+      },
+      {
+        "@type": "WorkflowStep",
+        "name": "Manual Input Invalid Indicator",
+        "description": null,
+        "arguments": {
+          "bot_response": "The indicator parameters provided were incorrect"
         },
-        {
-            "@type": "WorkflowStep",
-            "name": "Create Indicator",
-            "description": null,
-            "arguments": {
-                "for_each": {
-                    "item": "{{vars.steps.Extract_Artifact.data.results}}",
-                    "__bulk": true,
-                    "parallel": false,
-                    "condition": "",
-                    "batch_size": 100
-                },
-                "resource": {
-                    "tlp": "\/api\/3\/picklists\/7bff95b7-6438-4b01-b23a-0fe8cb5b33d3",
-                    "value": "{{vars.item.value}}",
-                    "__replace": "",
-                    "indicatorStatus": "\/api\/3\/picklists\/2f5cff61-fbff-4bb3-96be-302b78a9fb47",
-                    "typeofindicator": "{{vars.item['picklist_iri']}}",
-                    "enrichmentStatus": "\/api\/3\/picklists\/a6d9da29-27b1-4b8a-965d-8d91518540d5"
-                },
-                "operation": "Overwrite",
-                "collection": "\/api\/3\/indicators",
-                "__recommend": [],
-                "fieldOperation": {
-                    "recordTags": "Overwrite"
-                },
-                "step_variables": []
-            },
-            "status": null,
-            "top": "1110",
-            "left": "835",
-            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
-            "group": null,
-            "uuid": "35b8cf2b-8b74-4e2b-9d20-fc0e588f5689"
+        "status": null,
+        "top": "1245",
+        "left": "825",
+        "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+        "group": null,
+        "uuid": "184093ee-68a9-4f15-8afa-019e99658747"
+      },
+      {
+        "@type": "WorkflowStep",
+        "name": "Create Indicator",
+        "description": null,
+        "arguments": {
+          "for_each": {
+            "item": "{{vars.steps.Extract_Artifact.data.results}}",
+            "__bulk": true,
+            "parallel": false,
+            "condition": "",
+            "batch_size": 100
+          },
+          "resource": {
+            "tlp": "/api/3/picklists/7bff95b7-6438-4b01-b23a-0fe8cb5b33d3",
+            "value": "{{vars.item.value}}",
+            "__replace": "",
+            "indicatorStatus": "/api/3/picklists/2f5cff61-fbff-4bb3-96be-302b78a9fb47",
+            "typeofindicator": "{{vars.item['picklist_iri']}}",
+            "enrichmentStatus": "/api/3/picklists/a6d9da29-27b1-4b8a-965d-8d91518540d5"
+          },
+          "operation": "Overwrite",
+          "collection": "/api/3/indicators",
+          "__recommend": [],
+          "fieldOperation": {
+            "recordTags": "Overwrite"
+          },
+          "step_variables": []
         },
-        {
-            "@type": "WorkflowStep",
-            "name": "Cancel",
-            "description": null,
-            "arguments": {
-                "bot_response": "\"Indicator creation cancelled!\""
-            },
-            "status": null,
-            "top": "1245",
-            "left": "485",
-            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-            "group": null,
-            "uuid": "4dea72b0-041c-4a88-9a66-1d35ecea99cb"
+        "status": null,
+        "top": "1110",
+        "left": "475",
+        "stepType": "/api/3/workflow_step_types/2597053c-e718-44b4-8394-4d40fe26d357",
+        "group": null,
+        "uuid": "35b8cf2b-8b74-4e2b-9d20-fc0e588f5689"
+      },
+      {
+        "@type": "WorkflowStep",
+        "name": "Cancel",
+        "description": null,
+        "arguments": {
+          "bot_response": "\"Indicator creation cancelled!\""
         },
-        {
-            "@type": "WorkflowStep",
-            "name": "Extract Artifact",
-            "description": null,
-            "arguments": {
-                "name": "Utilities",
-                "params": {
-                    "data": "{{vars.indicator_val}} | string",
-                    "whitelist": "",
-                    "case_sensitive": false,
-                    "override_regex": false,
-                    "private_whitelist": true
-                },
-                "version": "3.2.3",
-                "connector": "cyops_utilities",
-                "operation": "extract_artifacts",
-                "operationTitle": "FSR: Extract Artifacts from String",
-                "pickFromTenant": false,
-                "step_variables": []
-            },
-            "status": null,
-            "top": "840",
-            "left": "1010",
-            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
-            "group": null,
-            "uuid": "53cdd8f7-068e-4a86-859e-1652ee2e44a3"
+        "status": null,
+        "top": "800",
+        "left": "1100",
+        "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+        "group": null,
+        "uuid": "4dea72b0-041c-4a88-9a66-1d35ecea99cb"
+      },
+      {
+        "@type": "WorkflowStep",
+        "name": "Extract Artifact",
+        "description": null,
+        "arguments": {
+          "name": "Utilities",
+          "params": {
+            "data": "{{vars.indicator_val}} | string",
+            "whitelist": "",
+            "case_sensitive": false,
+            "override_regex": false,
+            "private_whitelist": true
+          },
+          "version": "3.2.3",
+          "connector": "cyops_utilities",
+          "operation": "extract_artifacts",
+          "operationTitle": "FSR: Extract Artifacts from String",
+          "pickFromTenant": false,
+          "step_variables": []
         },
-        {
-            "@type": "WorkflowStep",
-            "name": "Incorrect Parameters",
-            "description": null,
-            "arguments": {
-                "bot_response": "The indicator parameters provided were incorrect"
-            },
-            "status": null,
-            "top": "1245",
-            "left": "1185",
-            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-            "group": null,
-            "uuid": "59dd8052-c04f-44b1-a365-9c526e612754"
+        "status": null,
+        "top": "840",
+        "left": "300",
+        "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+        "group": null,
+        "uuid": "53cdd8f7-068e-4a86-859e-1652ee2e44a3"
+      },
+      {
+        "@type": "WorkflowStep",
+        "name": "Incorrect Parameters",
+        "description": null,
+        "arguments": {
+          "bot_response": "The indicator parameters provided were incorrect"
         },
-        {
-            "@type": "WorkflowStep",
-            "name": "Response Step",
-            "description": null,
-            "arguments": {
-                "name": "Slack",
-                "config": "633e8bd0-a5d0-48a0-addd-2bc7174b9ceb",
-                "params": {
-                    "blocks": "",
-                    "channel": "{%if vars.bot_context.channel_id %}{{vars.bot_context.channel_id }}{%else%}{{vars.bot_context.user_id}}{%endif%}",
-                    "message": "{{vars.bot_response}}",
-                    "email_id": "",
-                    "thread_ts": "{{vars.bot_context.get('ts','')}}",
-                    "attachments": ""
-                },
-                "version": "3.0.0",
-                "connector": "slack",
-                "operation": "send_message",
-                "operationTitle": "Send Message",
-                "pickFromTenant": false,
-                "step_variables": []
-            },
-            "status": null,
-            "top": "1380",
-            "left": "660",
-            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
-            "group": null,
-            "uuid": "5e1e66c2-b89d-48f1-8302-f15165b84993"
+        "status": null,
+        "top": "1245",
+        "left": "125",
+        "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+        "group": null,
+        "uuid": "59dd8052-c04f-44b1-a365-9c526e612754"
+      },
+      {
+        "@type": "WorkflowStep",
+        "name": "Response Step",
+        "description": null,
+        "arguments": {
+          "name": "Slack",
+          "config": "633e8bd0-a5d0-48a0-addd-2bc7174b9ceb",
+          "params": {
+            "blocks": "",
+            "channel": "{{vars.bot_context.user_id}}",
+            "message": "{{vars.bot_response}}",
+            "email_id": "",
+            "thread_ts": "{{vars.bot_context.get('ts','')}}",
+            "attachments": ""
+          },
+          "version": "3.0.0",
+          "connector": "slack",
+          "operation": "send_message",
+          "operationTitle": "Send Message",
+          "pickFromTenant": false,
+          "step_variables": []
         },
-        {
-            "@type": "WorkflowStep",
-            "name": "Response",
-            "description": null,
-            "arguments": {
-                "bot_response": "Done! Indicator '{{vars.indicator_val}}' successfully added to the indicator list."
-            },
-            "status": null,
-            "top": "1245",
-            "left": "835",
-            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-            "group": null,
-            "uuid": "64a2be62-0a91-432d-9b4c-1f62adf76298"
+        "status": null,
+        "top": "1380",
+        "left": "650",
+        "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+        "group": null,
+        "uuid": "5e1e66c2-b89d-48f1-8302-f15165b84993"
+      },
+      {
+        "@type": "WorkflowStep",
+        "name": "Response",
+        "description": null,
+        "arguments": {
+          "bot_response": "Done! Indicator '{{vars.indicator_val}}' successfully added to the indicator list."
         },
-        {
-            "@type": "WorkflowStep",
-            "name": "Manual Input Form",
-            "description": null,
-            "arguments": {
-                "type": "InputBased",
-                "input": {
-                    "schema": {
-                        "title": "Create Indicator",
-                        "description": "Creates an indicator with the given fields in Fortisoar.",
-                        "inputVariables": [
-                            {
-                                "name": "indicator",
-                                "type": "string",
-                                "label": "Indicator",
-                                "tooltip": "",
-                                "dataType": "text",
-                                "formType": "text",
-                                "required": false,
-                                "_expanded": true,
-                                "defaultValue": null,
-                                "_previousName": "",
-                                "useRecordFieldDefault": false
-                            }
-                        ]
-                    }
-                },
-                "record": "",
-                "agent_id": null,
-                "owner_detail": {
-                    "isAssigned": false,
-                    "emailRecipients": "",
-                    "externalRecipients": "{{vars.user_id}}"
-                },
-                "isRecordLinked": false,
-                "step_variables": [],
-                "response_mapping": {
-                    "options": [
-                        {
-                            "option": "Create Indicator",
-                            "step_iri": "\/api\/3\/workflow_steps\/091bfa45-902c-4289-8813-0808f26a1ff8"
-                        },
-                        {
-                            "option": "Cancel",
-                            "step_iri": "\/api\/3\/workflow_steps\/4dea72b0-041c-4a88-9a66-1d35ecea99cb"
-                        }
-                    ],
-                    "duplicateOption": false
-                },
-                "inputExternalUser": false,
-                "email_notification": {
-                    "enabled": false,
-                    "smtpParameters": []
-                },
-                "inputInternalUsers": true,
-                "inline_channel_list": [
-                    "\/api\/3\/picklists\/afb18b7f-510b-471a-9b9c-7f4646edd4ee"
-                ],
-                "external_channel_list": [],
-                "unauthenticated_input": true
-            },
-            "status": null,
-            "top": "360",
-            "left": "620",
-            "stepType": "\/api\/3\/workflow_step_types\/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
-            "group": null,
-            "uuid": "6925505d-310b-4f10-80bc-842da7046769"
-        },
-        {
-            "@type": "WorkflowStep",
-            "name": "Start",
-            "description": null,
-            "arguments": {
-                "step_variables": {
-                    "input": {
-                        "params": []
-                    }
+        "status": null,
+        "top": "1245",
+        "left": "475",
+        "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+        "group": null,
+        "uuid": "64a2be62-0a91-432d-9b4c-1f62adf76298"
+      },
+      {
+        "@type": "WorkflowStep",
+        "name": "Manual Input Form",
+        "description": null,
+        "arguments": {
+          "type": "InputBased",
+          "input": {
+            "schema": {
+              "title": "Create Indicator",
+              "description": "Creates an indicator with the given fields in Fortisoar.",
+              "inputVariables": [
+                {
+                  "name": "indicator",
+                  "type": "string",
+                  "label": "Indicator",
+                  "tooltip": "",
+                  "dataType": "text",
+                  "formType": "text",
+                  "required": false,
+                  "_expanded": true,
+                  "defaultValue": null,
+                  "_previousName": "",
+                  "useRecordFieldDefault": false
                 }
-            },
-            "status": null,
-            "top": "30",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/b348f017-9a94-471f-87f8-ce88b6a7ad62",
-            "group": null,
-            "uuid": "978b6805-b07f-4876-b9aa-546ff464c163"
+              ]
+            }
+          },
+          "record": "",
+          "agent_id": null,
+          "owner_detail": {
+            "isAssigned": false,
+            "emailRecipients": "",
+            "externalRecipients": "{{vars.user_id}}"
+          },
+          "isRecordLinked": false,
+          "step_variables": [],
+          "response_mapping": {
+            "options": [
+              {
+                "option": "Create Indicator",
+                "step_iri": "/api/3/workflow_steps/091bfa45-902c-4289-8813-0808f26a1ff8"
+              },
+              {
+                "option": "Cancel",
+                "step_iri": "/api/3/workflow_steps/4dea72b0-041c-4a88-9a66-1d35ecea99cb"
+              }
+            ],
+            "duplicateOption": false
+          },
+          "inputExternalUser": false,
+          "email_notification": {
+            "enabled": false,
+            "smtpParameters": []
+          },
+          "inputInternalUsers": true,
+          "inline_channel_list": [
+            "/api/3/picklists/afb18b7f-510b-471a-9b9c-7f4646edd4ee"
+          ],
+          "external_channel_list": [],
+          "unauthenticated_input": true
         },
-        {
-            "@type": "WorkflowStep",
-            "name": "Configuration",
-            "description": null,
-            "arguments": {
-                "user_id": "{{vars.bot_context.channel_id}}",
-                "indicator_val": "{{vars.input.params.indicatorVal}}"
-            },
-            "status": null,
-            "top": "165",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-            "group": null,
-            "uuid": "d64ec03a-f3d6-43c7-8859-09796e5b5a09"
+        "status": null,
+        "top": "320",
+        "left": "1100",
+        "stepType": "/api/3/workflow_step_types/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
+        "group": null,
+        "uuid": "6925505d-310b-4f10-80bc-842da7046769"
+      },
+      {
+        "@type": "WorkflowStep",
+        "name": "Start",
+        "description": null,
+        "arguments": {
+          "step_variables": {
+            "input": {
+              "params": []
+            }
+          }
         },
-        {
-            "@type": "WorkflowStep",
-            "name": "Are Parameters Passed",
-            "description": null,
-            "arguments": {
-                "conditions": [
-                    {
-                        "option": "No",
-                        "default": true,
-                        "step_iri": "\/api\/3\/workflow_steps\/6925505d-310b-4f10-80bc-842da7046769",
-                        "step_name": "Manual Input Form"
-                    },
-                    {
-                        "option": "Yes",
-                        "step_iri": "\/api\/3\/workflow_steps\/117e01d2-5604-4f51-b800-6affa0de51fe",
-                        "condition": "{{ vars.indicator_val | string | length > 0 }}",
-                        "step_name": "Check Number of Indicator"
-                    }
-                ]
+        "status": null,
+        "top": "30",
+        "left": "650",
+        "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
+        "group": null,
+        "uuid": "978b6805-b07f-4876-b9aa-546ff464c163"
+      },
+      {
+        "@type": "WorkflowStep",
+        "name": "Temp Variable",
+        "description": null,
+        "arguments": [],
+        "status": null,
+        "top": "570",
+        "left": "300",
+        "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+        "group": null,
+        "uuid": "b89256b7-f00b-4234-bc95-e45dfdbd1896"
+      },
+      {
+        "@type": "WorkflowStep",
+        "name": "Configuration",
+        "description": null,
+        "arguments": {
+          "user_id": "{{vars.bot_context.channel_id}}",
+          "indicator_val": "{{vars.input.params.indicatorVal}}"
+        },
+        "status": null,
+        "top": "165",
+        "left": "650",
+        "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+        "group": null,
+        "uuid": "d64ec03a-f3d6-43c7-8859-09796e5b5a09"
+      },
+      {
+        "@type": "WorkflowStep",
+        "name": "Are Arguments Passed",
+        "description": null,
+        "arguments": {
+          "conditions": [
+            {
+              "option": "No",
+              "default": true,
+              "step_iri": "/api/3/workflow_steps/6925505d-310b-4f10-80bc-842da7046769",
+              "step_name": "Manual Input Form"
             },
-            "status": null,
-            "top": "300",
-            "left": "300",
-            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-            "group": null,
-            "uuid": "f93ddec2-3394-4095-8f4f-4bbfc2b6f372"
-        }
+            {
+              "option": "Yes",
+              "step_iri": "/api/3/workflow_steps/b89256b7-f00b-4234-bc95-e45dfdbd1896",
+              "condition": "{{ ((vars.indicator_val | string).strip() | length) > 0 }}",
+              "step_name": "Temp Variable"
+            }
+          ]
+        },
+        "status": null,
+        "top": "300",
+        "left": "650",
+        "stepType": "/api/3/workflow_step_types/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+        "group": null,
+        "uuid": "f93ddec2-3394-4095-8f4f-4bbfc2b6f372"
+      }
     ],
     "routes": [
-        {
-            "@type": "WorkflowRoute",
-            "name": "Show Manual Input Form Or Not -> Manual Input Form",
-            "targetStep": "\/api\/3\/workflow_steps\/6925505d-310b-4f10-80bc-842da7046769",
-            "sourceStep": "\/api\/3\/workflow_steps\/f93ddec2-3394-4095-8f4f-4bbfc2b6f372",
-            "label": "No",
-            "isExecuted": false,
-            "uuid": "0563e1bb-7811-4531-932c-d0a0d976bdfc"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Manual Input Invalid Indicator -> Response Step",
-            "targetStep": "\/api\/3\/workflow_steps\/5e1e66c2-b89d-48f1-8302-f15165b84993",
-            "sourceStep": "\/api\/3\/workflow_steps\/184093ee-68a9-4f15-8afa-019e99658747",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "065fe395-9f4a-4386-b7b9-94a8f3c75fd4"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Cancel -> Response Step",
-            "targetStep": "\/api\/3\/workflow_steps\/5e1e66c2-b89d-48f1-8302-f15165b84993",
-            "sourceStep": "\/api\/3\/workflow_steps\/4dea72b0-041c-4a88-9a66-1d35ecea99cb",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "16835c2a-0bf9-4486-93a3-0a65efa33014"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Configuration -> Show Manual Input Form Or Not",
-            "targetStep": "\/api\/3\/workflow_steps\/f93ddec2-3394-4095-8f4f-4bbfc2b6f372",
-            "sourceStep": "\/api\/3\/workflow_steps\/d64ec03a-f3d6-43c7-8859-09796e5b5a09",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "5ecfe7cd-3523-4e62-b78d-8a1457a6ca5d"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Manual Input Form -> Set Var",
-            "targetStep": "\/api\/3\/workflow_steps\/091bfa45-902c-4289-8813-0808f26a1ff8",
-            "sourceStep": "\/api\/3\/workflow_steps\/6925505d-310b-4f10-80bc-842da7046769",
-            "label": "Create Indicator",
-            "isExecuted": false,
-            "uuid": "62e8c675-f523-4790-87bc-77a603fe9e37"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Response -> Response Step",
-            "targetStep": "\/api\/3\/workflow_steps\/5e1e66c2-b89d-48f1-8302-f15165b84993",
-            "sourceStep": "\/api\/3\/workflow_steps\/64a2be62-0a91-432d-9b4c-1f62adf76298",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "76690ad0-753c-4631-885e-ba855aacd599"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Create Indicator -> Response",
-            "targetStep": "\/api\/3\/workflow_steps\/64a2be62-0a91-432d-9b4c-1f62adf76298",
-            "sourceStep": "\/api\/3\/workflow_steps\/35b8cf2b-8b74-4e2b-9d20-fc0e588f5689",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "79a6bc5e-3286-43ac-8826-3df6f40a7e20"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Start -> Configuration",
-            "targetStep": "\/api\/3\/workflow_steps\/d64ec03a-f3d6-43c7-8859-09796e5b5a09",
-            "sourceStep": "\/api\/3\/workflow_steps\/978b6805-b07f-4876-b9aa-546ff464c163",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "84ed4683-55e9-4bcf-a4c4-641eedefc526"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Incorrect Parameters -> Response Step",
-            "targetStep": "\/api\/3\/workflow_steps\/5e1e66c2-b89d-48f1-8302-f15165b84993",
-            "sourceStep": "\/api\/3\/workflow_steps\/59dd8052-c04f-44b1-a365-9c526e612754",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "bdfb1d04-5394-4371-a197-ebe48c69bd53"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Manual Input Form -> Cancel",
-            "targetStep": "\/api\/3\/workflow_steps\/4dea72b0-041c-4a88-9a66-1d35ecea99cb",
-            "sourceStep": "\/api\/3\/workflow_steps\/6925505d-310b-4f10-80bc-842da7046769",
-            "label": "Cancel",
-            "isExecuted": false,
-            "uuid": "bf8fbb07-b218-4d95-b66d-4369c0d7441c"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Check Length of Indicator -> Extract Artifact",
-            "targetStep": "\/api\/3\/workflow_steps\/53cdd8f7-068e-4a86-859e-1652ee2e44a3",
-            "sourceStep": "\/api\/3\/workflow_steps\/117e01d2-5604-4f51-b800-6affa0de51fe",
-            "label": "Params Passed",
-            "isExecuted": false,
-            "uuid": "ceb95deb-af15-4875-b02d-832698a7b59f"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Indicator Validation -> No",
-            "targetStep": "\/api\/3\/workflow_steps\/59dd8052-c04f-44b1-a365-9c526e612754",
-            "sourceStep": "\/api\/3\/workflow_steps\/0e715216-3a72-444a-bfde-2f418f60d505",
-            "label": "Invalid",
-            "isExecuted": false,
-            "uuid": "d0387ac7-c642-4e48-b716-18b4a53b9c2f"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Set Var -> Check Length of Indicator",
-            "targetStep": "\/api\/3\/workflow_steps\/117e01d2-5604-4f51-b800-6affa0de51fe",
-            "sourceStep": "\/api\/3\/workflow_steps\/091bfa45-902c-4289-8813-0808f26a1ff8",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "e3224290-1dc6-45f0-9ed9-848fc573599d"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Check Length of Indicator -> Manual Input Invalid Indicator",
-            "targetStep": "\/api\/3\/workflow_steps\/184093ee-68a9-4f15-8afa-019e99658747",
-            "sourceStep": "\/api\/3\/workflow_steps\/117e01d2-5604-4f51-b800-6affa0de51fe",
-            "label": "Params Blank",
-            "isExecuted": false,
-            "uuid": "ea458b47-b20f-4fa9-a94d-273a99c16f5e"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Indicator Validation -> Create Indicator",
-            "targetStep": "\/api\/3\/workflow_steps\/35b8cf2b-8b74-4e2b-9d20-fc0e588f5689",
-            "sourceStep": "\/api\/3\/workflow_steps\/0e715216-3a72-444a-bfde-2f418f60d505",
-            "label": "Valid",
-            "isExecuted": false,
-            "uuid": "f50f058a-460b-4a1a-9b87-9d3d6dcffd90"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Extract Artifact -> Is Valid Indicator",
-            "targetStep": "\/api\/3\/workflow_steps\/0e715216-3a72-444a-bfde-2f418f60d505",
-            "sourceStep": "\/api\/3\/workflow_steps\/53cdd8f7-068e-4a86-859e-1652ee2e44a3",
-            "label": null,
-            "isExecuted": false,
-            "uuid": "5eacbd1c-2be1-4bed-9f76-11a1425b9bbd"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Are Parameters Passed -> Check Number of Indicator",
-            "targetStep": "\/api\/3\/workflow_steps\/117e01d2-5604-4f51-b800-6affa0de51fe",
-            "sourceStep": "\/api\/3\/workflow_steps\/f93ddec2-3394-4095-8f4f-4bbfc2b6f372",
-            "label": "Yes",
-            "isExecuted": false,
-            "uuid": "78b0946d-71b8-4a5d-87f6-86134c2741e8"
-        }
+      {
+        "@type": "WorkflowRoute",
+        "name": "Manual Input Invalid Indicator -> Response Step",
+        "targetStep": "/api/3/workflow_steps/5e1e66c2-b89d-48f1-8302-f15165b84993",
+        "sourceStep": "/api/3/workflow_steps/184093ee-68a9-4f15-8afa-019e99658747",
+        "label": null,
+        "isExecuted": false,
+        "uuid": "065fe395-9f4a-4386-b7b9-94a8f3c75fd4"
+      },
+      {
+        "@type": "WorkflowRoute",
+        "name": "Cancel -> Response Step",
+        "targetStep": "/api/3/workflow_steps/5e1e66c2-b89d-48f1-8302-f15165b84993",
+        "sourceStep": "/api/3/workflow_steps/4dea72b0-041c-4a88-9a66-1d35ecea99cb",
+        "label": null,
+        "isExecuted": false,
+        "uuid": "16835c2a-0bf9-4486-93a3-0a65efa33014"
+      },
+      {
+        "@type": "WorkflowRoute",
+        "name": "Configuration -> Show Manual Input Form Or Not",
+        "targetStep": "/api/3/workflow_steps/f93ddec2-3394-4095-8f4f-4bbfc2b6f372",
+        "sourceStep": "/api/3/workflow_steps/d64ec03a-f3d6-43c7-8859-09796e5b5a09",
+        "label": null,
+        "isExecuted": false,
+        "uuid": "5ecfe7cd-3523-4e62-b78d-8a1457a6ca5d"
+      },
+      {
+        "@type": "WorkflowRoute",
+        "name": "Manual Input Form -> Set Var",
+        "targetStep": "/api/3/workflow_steps/091bfa45-902c-4289-8813-0808f26a1ff8",
+        "sourceStep": "/api/3/workflow_steps/6925505d-310b-4f10-80bc-842da7046769",
+        "label": "Create Indicator",
+        "isExecuted": false,
+        "uuid": "62e8c675-f523-4790-87bc-77a603fe9e37"
+      },
+      {
+        "@type": "WorkflowRoute",
+        "name": "Response -> Response Step",
+        "targetStep": "/api/3/workflow_steps/5e1e66c2-b89d-48f1-8302-f15165b84993",
+        "sourceStep": "/api/3/workflow_steps/64a2be62-0a91-432d-9b4c-1f62adf76298",
+        "label": null,
+        "isExecuted": false,
+        "uuid": "76690ad0-753c-4631-885e-ba855aacd599"
+      },
+      {
+        "@type": "WorkflowRoute",
+        "name": "Create Indicator -> Response",
+        "targetStep": "/api/3/workflow_steps/64a2be62-0a91-432d-9b4c-1f62adf76298",
+        "sourceStep": "/api/3/workflow_steps/35b8cf2b-8b74-4e2b-9d20-fc0e588f5689",
+        "label": null,
+        "isExecuted": false,
+        "uuid": "79a6bc5e-3286-43ac-8826-3df6f40a7e20"
+      },
+      {
+        "@type": "WorkflowRoute",
+        "name": "Start -> Configuration",
+        "targetStep": "/api/3/workflow_steps/d64ec03a-f3d6-43c7-8859-09796e5b5a09",
+        "sourceStep": "/api/3/workflow_steps/978b6805-b07f-4876-b9aa-546ff464c163",
+        "label": null,
+        "isExecuted": false,
+        "uuid": "84ed4683-55e9-4bcf-a4c4-641eedefc526"
+      },
+      {
+        "@type": "WorkflowRoute",
+        "name": "Incorrect Parameters -> Response Step",
+        "targetStep": "/api/3/workflow_steps/5e1e66c2-b89d-48f1-8302-f15165b84993",
+        "sourceStep": "/api/3/workflow_steps/59dd8052-c04f-44b1-a365-9c526e612754",
+        "label": null,
+        "isExecuted": false,
+        "uuid": "bdfb1d04-5394-4371-a197-ebe48c69bd53"
+      },
+      {
+        "@type": "WorkflowRoute",
+        "name": "Manual Input Form -> Cancel",
+        "targetStep": "/api/3/workflow_steps/4dea72b0-041c-4a88-9a66-1d35ecea99cb",
+        "sourceStep": "/api/3/workflow_steps/6925505d-310b-4f10-80bc-842da7046769",
+        "label": "Cancel",
+        "isExecuted": false,
+        "uuid": "bf8fbb07-b218-4d95-b66d-4369c0d7441c"
+      },
+      {
+        "@type": "WorkflowRoute",
+        "name": "Check Length of Indicator -> Extract Artifact",
+        "targetStep": "/api/3/workflow_steps/53cdd8f7-068e-4a86-859e-1652ee2e44a3",
+        "sourceStep": "/api/3/workflow_steps/117e01d2-5604-4f51-b800-6affa0de51fe",
+        "label": "Params Passed",
+        "isExecuted": false,
+        "uuid": "ceb95deb-af15-4875-b02d-832698a7b59f"
+      },
+      {
+        "@type": "WorkflowRoute",
+        "name": "Indicator Validation -> No",
+        "targetStep": "/api/3/workflow_steps/59dd8052-c04f-44b1-a365-9c526e612754",
+        "sourceStep": "/api/3/workflow_steps/0e715216-3a72-444a-bfde-2f418f60d505",
+        "label": "Invalid",
+        "isExecuted": false,
+        "uuid": "d0387ac7-c642-4e48-b716-18b4a53b9c2f"
+      },
+      {
+        "@type": "WorkflowRoute",
+        "name": "Set Var -> Check Length of Indicator",
+        "targetStep": "/api/3/workflow_steps/117e01d2-5604-4f51-b800-6affa0de51fe",
+        "sourceStep": "/api/3/workflow_steps/091bfa45-902c-4289-8813-0808f26a1ff8",
+        "label": null,
+        "isExecuted": false,
+        "uuid": "e3224290-1dc6-45f0-9ed9-848fc573599d"
+      },
+      {
+        "@type": "WorkflowRoute",
+        "name": "Check Length of Indicator -> Manual Input Invalid Indicator",
+        "targetStep": "/api/3/workflow_steps/184093ee-68a9-4f15-8afa-019e99658747",
+        "sourceStep": "/api/3/workflow_steps/117e01d2-5604-4f51-b800-6affa0de51fe",
+        "label": "Params Blank",
+        "isExecuted": false,
+        "uuid": "ea458b47-b20f-4fa9-a94d-273a99c16f5e"
+      },
+      {
+        "@type": "WorkflowRoute",
+        "name": "Indicator Validation -> Create Indicator",
+        "targetStep": "/api/3/workflow_steps/35b8cf2b-8b74-4e2b-9d20-fc0e588f5689",
+        "sourceStep": "/api/3/workflow_steps/0e715216-3a72-444a-bfde-2f418f60d505",
+        "label": "Valid",
+        "isExecuted": false,
+        "uuid": "f50f058a-460b-4a1a-9b87-9d3d6dcffd90"
+      },
+      {
+        "@type": "WorkflowRoute",
+        "name": "Extract Artifact -> Is Valid Indicator",
+        "targetStep": "/api/3/workflow_steps/0e715216-3a72-444a-bfde-2f418f60d505",
+        "sourceStep": "/api/3/workflow_steps/53cdd8f7-068e-4a86-859e-1652ee2e44a3",
+        "label": null,
+        "isExecuted": false,
+        "uuid": "5eacbd1c-2be1-4bed-9f76-11a1425b9bbd"
+      },
+      {
+        "@type": "WorkflowRoute",
+        "name": "Are Parameters Passed -> Copy 1 of Set Indicator",
+        "targetStep": "/api/3/workflow_steps/b89256b7-f00b-4234-bc95-e45dfdbd1896",
+        "sourceStep": "/api/3/workflow_steps/f93ddec2-3394-4095-8f4f-4bbfc2b6f372",
+        "label": "Yes",
+        "isExecuted": false,
+        "uuid": "ceaaab5e-694d-4a0b-9946-01386abc3a06"
+      },
+      {
+        "@type": "WorkflowRoute",
+        "name": "Copy 1 of Set Indicator -> Check for blank form submission",
+        "targetStep": "/api/3/workflow_steps/117e01d2-5604-4f51-b800-6affa0de51fe",
+        "sourceStep": "/api/3/workflow_steps/b89256b7-f00b-4234-bc95-e45dfdbd1896",
+        "label": null,
+        "isExecuted": false,
+        "uuid": "52bc6762-ddbe-4319-9f9c-a554e3538cbf"
+      },
+      {
+        "@type": "WorkflowRoute",
+        "name": "Are Parameters Passed -> Manual Input Form",
+        "targetStep": "/api/3/workflow_steps/6925505d-310b-4f10-80bc-842da7046769",
+        "sourceStep": "/api/3/workflow_steps/f93ddec2-3394-4095-8f4f-4bbfc2b6f372",
+        "label": "No",
+        "isExecuted": false,
+        "uuid": "a806fd90-b3ef-4719-bd4c-99f6ce4ac688"
+      }
     ],
     "groups": [],
-    "priority": "\/api\/3\/picklists\/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
+    "priority": "/api/3/picklists/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
     "uuid": "a293b1d7-4fef-47a8-8632-cc8893e355e3",
+    "id": 476,
     "owners": [],
     "isPrivate": false,
     "deletedAt": null,
+    "importedBy": [
+      {
+        "apiName": "fortiSOARForSlack",
+        "name": "FortiSOAR For Slack",
+        "version": "1.0.0"
+      }
+    ],
     "recordTags": [
-        "bot_enabled",
-        "createIndicator"
+      "bot_enabled",
+      "createIndicator"
     ]
-}
+  }

--- a/playbooks/02 - Use Case - FortiSOAR for Slack/Create Indicator.json
+++ b/playbooks/02 - Use Case - FortiSOAR for Slack/Create Indicator.json
@@ -198,7 +198,7 @@
                 "config": "633e8bd0-a5d0-48a0-addd-2bc7174b9ceb",
                 "params": {
                     "blocks": "",
-                    "channel": "{{vars.bot_context.user_id}}",
+                    "channel": "{%if vars.bot_context.channel_id %}{{vars.bot_context.channel_id }}{%else%}{{vars.bot_context.user_id}}{%endif%}",
                     "message": "{{vars.bot_response}}",
                     "email_id": "",
                     "thread_ts": "{{vars.bot_context.get('ts','')}}",

--- a/playbooks/02 - Use Case - FortiSOAR for Slack/Create Indicator.json
+++ b/playbooks/02 - Use Case - FortiSOAR for Slack/Create Indicator.json
@@ -199,7 +199,7 @@
           "config": "633e8bd0-a5d0-48a0-addd-2bc7174b9ceb",
           "params": {
             "blocks": "",
-            "channel": "{{vars.bot_context.user_id}}",
+            "channel": "{%if vars.bot_context.channel_id %}{{vars.bot_context.channel_id }}{%else%}{{vars.bot_context.user_id}}{%endif%}",
             "message": "{{vars.bot_response}}",
             "email_id": "",
             "thread_ts": "{{vars.bot_context.get('ts','')}}",

--- a/playbooks/02 - Use Case - FortiSOAR for Slack/Enrich IP From Slack.json
+++ b/playbooks/02 - Use Case - FortiSOAR for Slack/Enrich IP From Slack.json
@@ -370,7 +370,7 @@
             "name": "Connectors not configured",
             "description": null,
             "arguments": {
-                "bot_response": "[\n\t\t{\n\t\t\t\"type\": \"section\",\n\t\t\t\"text\": {\n\t\t\t\t\"type\": \"plain_text\",\n\t\t\t\t\"text\": \"The virustotal\/ipstack connector have not been configured\",\n\t\t\t\t\"emoji\": true\n\t\t\t}\n\t\t}\n\t]"
+                "bot_response": "[\n\t\t{\n\t\t\t\"type\": \"section\",\n\t\t\t\"text\": {\n\t\t\t\t\"type\": \"plain_text\",\n\t\t\t\t\"text\": \"The virustotal\/ipstack connector has not been configured\",\n\t\t\t\t\"emoji\": true\n\t\t\t}\n\t\t}\n\t]"
             },
             "status": null,
             "top": "1650",

--- a/rules/Slack > Notify On Playbook Failure.json
+++ b/rules/Slack > Notify On Playbook Failure.json
@@ -1,0 +1,55 @@
+{
+    "uuid": "fdd73027-c3bc-4f66-9be5-4a7054abfde4",
+    "name": "Slack > Notify On Playbook Failure",
+    "entity_type": "workflow_logs",
+    "event_type": "failed",
+    "trigger_condition": {
+        "sort": [],
+        "limit": 30,
+        "logic": "AND",
+        "filters": [
+            {
+                "type": "array",
+                "field": "recordTags",
+                "value": [
+                    "\/api\/3\/tags\/bot_enabled"
+                ],
+                "module": "recordTags",
+                "display": "",
+                "operator": "in",
+                "template": "tags",
+                "OPERATOR_KEY": "$",
+                "useInOperator": true,
+                "previousOperator": "in",
+                "previousTemplate": "tags"
+            }
+        ]
+    },
+    "actions": [
+        {
+            "type": "connector",
+            "params": {
+                "blocks": [],
+                "channel": "{{vars.input.record.bot_context['user_id']}}",
+                "message": "\"{{vars.input.record.name}}\" Playbook has failed. Please check the \"Executed Playbook Logs\" in FortiSOAR.",
+                "email_id": "",
+                "thread_ts": "",
+                "attachments": ""
+            },
+            "enabled": true,
+            "channel_uuid": "79fb4d6e-d7b1-4e22-9ad4-6a0f96fabaea"
+        }
+    ],
+    "is_system": false,
+    "is_active": true,
+    "priority": 10,
+    "event_source": "sealab",
+    "source": null,
+    "channel_preference_field": null,
+    "visible": true,
+    "category": "generic",
+    "expiry": null,
+    "entity_id": null,
+    "parent_rule": null,
+    "workflow": null
+}


### PR DESCRIPTION
#### Descriptions:
Added Delivery Rule when playbook triggered via slack fails
Changed the user_id to channel_id/user_id for createIndicator response step

UTC:
1. On playbook failure the message is displayed ""<PlaybookName>" Playbook has failed. Please check the "Executed Playbook Logs" in FortiSOAR."