### PR TITLE
Release/1.0.0

### DIFF
--- a/playbooks/02 - Use Case - FortiSOAR for Slack/Create Indicator.json
+++ b/playbooks/02 - Use Case - FortiSOAR for Slack/Create Indicator.json
@@ -224,7 +224,7 @@
         "name": "Response",
         "description": null,
         "arguments": {
-          "bot_response": "Done! Indicator '{{vars.indicator_val}}' successfully added to the indicator list."
+          "bot_response": "Done! Indicator '<{{vars.indicator_val}}>' successfully added to the indicator list."
         },
         "status": null,
         "top": "1245",

--- a/rules/Slack > Send Manual Input Link To Slack.json
+++ b/rules/Slack > Send Manual Input Link To Slack.json
@@ -39,7 +39,7 @@
                 "blocks": "[ \t\t{ \t\t\t\"type\": \"section\", \t\t\t\"text\": { \t\t\t\t\"type\": \"mrkdwn\", \t\t\t\t\"text\": \"A FortiSOAR playbook is requesting your input.\" \t\t\t} \t\t}, \t\t{ \t\t\t\"type\": \"section\", \t\t\t\"text\": { \t\t\t\t\"type\": \"mrkdwn\", \t\t\t\t\"text\": \"Please provide your input using the following link:  <https:\/\/{{vars.input.record.server_fqhn | ternary(vars.input.record.server_fqhn, globalVars.Server_fqhn)}}\/{{vars.input.record.agent_id | ternary('', 'input')}}?inputId={{vars.input.record.id}}&amp;token={{vars.input.record.token}}|Open input form>\" \t\t\t} \t\t}, \t\t{ \t\t\t\"type\": \"section\", \t\t\t\"text\": { \t\t\t\t\"type\": \"mrkdwn\", \t\t\t\t\"text\": \"Regards,\" \t\t\t} \t\t}, \t\t{ \t\t\t\"type\": \"section\", \t\t\t\"text\": { \t\t\t\t\"type\": \"mrkdwn\", \t\t\t\t\"text\": \"FortiSOAR Admin.\" \t\t\t} \t\t} \t]",
                 "channel": "{{vars.input.record.input.bot_context.user_id}}",
                 "message": "Done!",
-                "email_id": "",
+                "email_id": "{{vars.input.record.owner_details.emailRecipients}}",
                 "thread_ts": "",
                 "attachments": []
             },


### PR DESCRIPTION
#### Descriptions:
Change in rule, populated email-id field in the link rule
Change in indicator playbook, made indicator link non clickable

UTC:
Invoked playbook from FSR, message is received in Slack
The if Indicator is a URL the link is non clickable