### PR TITLE
sIndicators should not have '<>'

### DIFF
--- a/playbooks/02 - Use Case - FortiSOAR for Slack/Create Indicator.json
+++ b/playbooks/02 - Use Case - FortiSOAR for Slack/Create Indicator.json
@@ -1,669 +1,665 @@
 {
-    "@type": "Workflow",
-    "triggerLimit": null,
-    "name": "Create Indicator",
-    "aliasName": null,
-    "tag": null,
-    "description": "Gets triggered on createIndicator command when used in slack",
-    "isActive": true,
-    "debug": false,
-    "singleRecordExecution": false,
-    "remoteExecutableFlag": false,
-    "parameters": [
-      "indicatorVal"
-    ],
-    "synchronous": false,
-    "lastModifyDate": 1673534566,
-    "collection": "/api/3/workflow_collections/49291f43-e8a1-4f63-80b5-d88e05044a4a",
-    "versions": [],
-    "triggerStep": "/api/3/workflow_steps/978b6805-b07f-4876-b9aa-546ff464c163",
-    "steps": [
-      {
-        "@type": "WorkflowStep",
-        "name": "Set Indicator",
-        "description": null,
-        "arguments": {
-          "indicator_val": "{{vars.steps.Manual_Input_Form.input.indicator}}"
-        },
-        "status": null,
-        "top": "560",
-        "left": "960",
-        "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-        "group": null,
-        "uuid": "091bfa45-902c-4289-8813-0808f26a1ff8"
+  "@type": "Workflow",
+  "triggerLimit": null,
+  "name": "Create Indicator",
+  "aliasName": null,
+  "tag": null,
+  "description": "Gets triggered on createIndicator command when used in slack",
+  "isActive": true,
+  "debug": false,
+  "singleRecordExecution": false,
+  "remoteExecutableFlag": false,
+  "parameters": [
+    "indicatorVal"
+  ],
+  "synchronous": false,
+  "lastModifyDate": 1673935758,
+  "collection": "/api/3/workflow_collections/49291f43-e8a1-4f63-80b5-d88e05044a4a",
+  "versions": [],
+  "triggerStep": "/api/3/workflow_steps/978b6805-b07f-4876-b9aa-546ff464c163",
+  "steps": [
+    {
+      "@type": "WorkflowStep",
+      "name": "Set Indicator",
+      "description": null,
+      "arguments": {
+        "indicator_val": "{{vars.steps.Manual_Input_Form.input.indicator}}"
       },
-      {
-        "@type": "WorkflowStep",
-        "name": "Is Valid Indicator",
-        "description": null,
-        "arguments": {
-          "conditions": [
+      "status": null,
+      "top": "560",
+      "left": "960",
+      "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+      "group": null,
+      "uuid": "091bfa45-902c-4289-8813-0808f26a1ff8"
+    },
+    {
+      "@type": "WorkflowStep",
+      "name": "Is Valid Indicator",
+      "description": null,
+      "arguments": {
+        "conditions": [
+          {
+            "option": "Invalid",
+            "default": true,
+            "step_iri": "/api/3/workflow_steps/59dd8052-c04f-44b1-a365-9c526e612754",
+            "step_name": "Incorrect Parameters"
+          },
+          {
+            "option": "Valid",
+            "step_iri": "/api/3/workflow_steps/4379893f-4fb8-4fd5-80d7-650a2f5d8947",
+            "condition": "{{ vars.steps.Extract_Artifact.data.results| length > 0 }}",
+            "step_name": "Find Indicator"
+          }
+        ]
+      },
+      "status": null,
+      "top": "975",
+      "left": "475",
+      "stepType": "/api/3/workflow_step_types/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+      "group": null,
+      "uuid": "0e715216-3a72-444a-bfde-2f418f60d505"
+    },
+    {
+      "@type": "WorkflowStep",
+      "name": "Check for blank form submission",
+      "description": null,
+      "arguments": {
+        "conditions": [
+          {
+            "option": "Params Passed",
+            "step_iri": "/api/3/workflow_steps/53cdd8f7-068e-4a86-859e-1652ee2e44a3",
+            "condition": "{{ (vars.indicator_val != None) }}",
+            "step_name": "Extract Artifact"
+          },
+          {
+            "option": "Params Blank",
+            "default": true,
+            "step_iri": "/api/3/workflow_steps/184093ee-68a9-4f15-8afa-019e99658747",
+            "step_name": "Manual Input Invalid Indicator"
+          }
+        ]
+      },
+      "status": null,
+      "top": "705",
+      "left": "650",
+      "stepType": "/api/3/workflow_step_types/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+      "group": null,
+      "uuid": "117e01d2-5604-4f51-b800-6affa0de51fe"
+    },
+    {
+      "@type": "WorkflowStep",
+      "name": "Manual Input Invalid Indicator",
+      "description": null,
+      "arguments": {
+        "bot_response": "[\n\t\t{\n\t\t\t\"type\": \"section\",\n\t\t\t\"text\": {\n\t\t\t\t\"type\": \"plain_text\",\n\t\t\t\t\"text\": \"The indicator parameters provided were incorrect.\"\n\t\t\t}\n\t\t}\n\t]"
+      },
+      "status": null,
+      "top": "1515",
+      "left": "1175",
+      "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+      "group": null,
+      "uuid": "184093ee-68a9-4f15-8afa-019e99658747"
+    },
+    {
+      "@type": "WorkflowStep",
+      "name": "Indicator already present",
+      "description": null,
+      "arguments": {
+        "bot_response": "[\n\t\t{\n\t\t\t\"type\": \"section\",\n\t\t\t\"text\": {\n\t\t\t\t\"type\": \"plain_text\",\n\t\t\t\t\"text\": \"Indicator already present!\"\n\t\t\t}\n\t\t}\n\t]"
+      },
+      "status": null,
+      "top": "1515",
+      "left": "825",
+      "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+      "group": null,
+      "uuid": "2e0879ec-e5c1-4ae2-9593-33c5df428f48"
+    },
+    {
+      "@type": "WorkflowStep",
+      "name": "Create Indicator",
+      "description": null,
+      "arguments": {
+        "for_each": {
+          "item": "{{vars.steps.Extract_Artifact.data.results}}",
+          "__bulk": true,
+          "parallel": false,
+          "condition": "",
+          "batch_size": 100
+        },
+        "resource": {
+          "tlp": "/api/3/picklists/7bff95b7-6438-4b01-b23a-0fe8cb5b33d3",
+          "value": "{{vars.item.value}}",
+          "__replace": "false",
+          "indicatorStatus": "/api/3/picklists/2f5cff61-fbff-4bb3-96be-302b78a9fb47",
+          "typeofindicator": "{{vars.item['picklist_iri']}}",
+          "enrichmentStatus": "/api/3/picklists/a6d9da29-27b1-4b8a-965d-8d91518540d5"
+        },
+        "operation": "Overwrite",
+        "collection": "/api/3/upsert/indicators",
+        "__recommend": [],
+        "fieldOperation": {
+          "recordTags": "Overwrite"
+        },
+        "step_variables": []
+      },
+      "status": null,
+      "top": "1380",
+      "left": "475",
+      "stepType": "/api/3/workflow_step_types/2597053c-e718-44b4-8394-4d40fe26d357",
+      "group": null,
+      "uuid": "35b8cf2b-8b74-4e2b-9d20-fc0e588f5689"
+    },
+    {
+      "@type": "WorkflowStep",
+      "name": "Find Indicator",
+      "description": null,
+      "arguments": {
+        "query": {
+          "sort": [],
+          "limit": 30,
+          "logic": "AND",
+          "filters": [
             {
-              "option": "Invalid",
-              "default": true,
-              "step_iri": "/api/3/workflow_steps/59dd8052-c04f-44b1-a365-9c526e612754",
-              "step_name": "Incorrect Parameters"
-            },
-            {
-              "option": "Valid",
-              "step_iri": "/api/3/workflow_steps/4379893f-4fb8-4fd5-80d7-650a2f5d8947",
-              "condition": "{{ vars.steps.Extract_Artifact.data.results| length > 0 }}",
-              "step_name": "Find Indicator"
+              "type": "primitive",
+              "field": "value",
+              "value": "{{vars.indicator_val}}",
+              "operator": "eq",
+              "_operator": "eq"
             }
           ]
         },
-        "status": null,
-        "top": "975",
-        "left": "475",
-        "stepType": "/api/3/workflow_step_types/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-        "group": null,
-        "uuid": "0e715216-3a72-444a-bfde-2f418f60d505"
+        "module": "indicators?$limit=30",
+        "step_variables": []
       },
-      {
-        "@type": "WorkflowStep",
-        "name": "Check for blank form submission",
-        "description": null,
-        "arguments": {
-          "conditions": [
-            {
-              "option": "Params Passed",
-              "step_iri": "/api/3/workflow_steps/53cdd8f7-068e-4a86-859e-1652ee2e44a3",
-              "condition": "{{ (vars.indicator_val != None) }}",
-              "step_name": "Extract Artifact"
-            },
-            {
-              "option": "Params Blank",
-              "default": true,
-              "step_iri": "/api/3/workflow_steps/184093ee-68a9-4f15-8afa-019e99658747",
-              "step_name": "Manual Input Invalid Indicator"
-            }
-          ]
+      "status": null,
+      "top": "1110",
+      "left": "650",
+      "stepType": "/api/3/workflow_step_types/b593663d-7d13-40ce-a3a3-96dece928770",
+      "group": null,
+      "uuid": "4379893f-4fb8-4fd5-80d7-650a2f5d8947"
+    },
+    {
+      "@type": "WorkflowStep",
+      "name": "Cancel",
+      "description": null,
+      "arguments": {
+        "bot_response": "[\n\t\t{\n\t\t\t\"type\": \"section\",\n\t\t\t\"text\": {\n\t\t\t\t\"type\": \"plain_text\",\n\t\t\t\t\"text\": \"Indicator creation cancelled!\"\n\t\t\t}\n\t\t}\n\t]"
+      },
+      "status": null,
+      "top": "1660",
+      "left": "1360",
+      "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+      "group": null,
+      "uuid": "4dea72b0-041c-4a88-9a66-1d35ecea99cb"
+    },
+    {
+      "@type": "WorkflowStep",
+      "name": "Extract Artifact",
+      "description": null,
+      "arguments": {
+        "name": "Utilities",
+        "params": {
+          "data": "{{vars.indicator_val}} | string",
+          "whitelist": "",
+          "case_sensitive": false,
+          "override_regex": false,
+          "private_whitelist": true
         },
-        "status": null,
-        "top": "705",
-        "left": "650",
-        "stepType": "/api/3/workflow_step_types/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-        "group": null,
-        "uuid": "117e01d2-5604-4f51-b800-6affa0de51fe"
+        "version": "3.2.3",
+        "connector": "cyops_utilities",
+        "operation": "extract_artifacts",
+        "operationTitle": "FSR: Extract Artifacts from String",
+        "pickFromTenant": false,
+        "step_variables": []
       },
-      {
-        "@type": "WorkflowStep",
-        "name": "Manual Input Invalid Indicator",
-        "description": null,
-        "arguments": {
-          "bot_response": "The indicator parameters provided were incorrect"
+      "status": null,
+      "top": "840",
+      "left": "475",
+      "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+      "group": null,
+      "uuid": "53cdd8f7-068e-4a86-859e-1652ee2e44a3"
+    },
+    {
+      "@type": "WorkflowStep",
+      "name": "Incorrect Parameters",
+      "description": null,
+      "arguments": {
+        "bot_response": "[\n\t\t{\n\t\t\t\"type\": \"section\",\n\t\t\t\"text\": {\n\t\t\t\t\"type\": \"plain_text\",\n\t\t\t\t\"text\": \"The indicator parameters provided were incorrect.\"\n\t\t\t}\n\t\t}\n\t]"
+      },
+      "status": null,
+      "top": "1660",
+      "left": "200",
+      "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+      "group": null,
+      "uuid": "59dd8052-c04f-44b1-a365-9c526e612754"
+    },
+    {
+      "@type": "WorkflowStep",
+      "name": "Response Step",
+      "description": null,
+      "arguments": {
+        "name": "Slack",
+        "config": "633e8bd0-a5d0-48a0-addd-2bc7174b9ceb",
+        "params": {
+          "blocks": "{{vars.bot_response}}",
+          "channel": "{%if vars.bot_context.channel_id %}{{vars.bot_context.channel_id }}{%else%}{{vars.bot_context.user_id}}{%endif%}",
+          "message": "Block Response",
+          "email_id": "",
+          "thread_ts": "{{vars.bot_context.get('ts','')}}",
+          "attachments": ""
         },
-        "status": null,
-        "top": "1515",
-        "left": "1175",
-        "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-        "group": null,
-        "uuid": "184093ee-68a9-4f15-8afa-019e99658747"
+        "version": "3.0.0",
+        "connector": "slack",
+        "operation": "send_message",
+        "operationTitle": "Send Message",
+        "pickFromTenant": false,
+        "step_variables": []
       },
-      {
-        "@type": "WorkflowStep",
-        "name": "Indicator already present",
-        "description": null,
-        "arguments": {
-          "bot_response": "\"Indicator already present!\""
-        },
-        "status": null,
-        "top": "1515",
-        "left": "825",
-        "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-        "group": null,
-        "uuid": "2e0879ec-e5c1-4ae2-9593-33c5df428f48"
+      "status": null,
+      "top": "1650",
+      "left": "825",
+      "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
+      "group": null,
+      "uuid": "5e1e66c2-b89d-48f1-8302-f15165b84993"
+    },
+    {
+      "@type": "WorkflowStep",
+      "name": "Response",
+      "description": null,
+      "arguments": {
+        "bot_response": "[\n\t\t{\n\t\t\t\"type\": \"section\",\n\t\t\t\"text\": {\n\t\t\t\t\"type\": \"plain_text\",\n\t\t\t\t\"text\": \"Done! Indicator '{{vars.indicator_val}}' successfully added to the indicator list.\"\n\t\t\t}\n\t\t}\n\t]"
       },
-      {
-        "@type": "WorkflowStep",
-        "name": "Create Indicator",
-        "description": null,
-        "arguments": {
-          "for_each": {
-            "item": "{{vars.steps.Extract_Artifact.data.results}}",
-            "__bulk": true,
-            "parallel": false,
-            "condition": "",
-            "batch_size": 100
-          },
-          "resource": {
-            "tlp": "/api/3/picklists/7bff95b7-6438-4b01-b23a-0fe8cb5b33d3",
-            "value": "{{vars.item.value}}",
-            "__replace": "false",
-            "indicatorStatus": "/api/3/picklists/2f5cff61-fbff-4bb3-96be-302b78a9fb47",
-            "typeofindicator": "{{vars.item['picklist_iri']}}",
-            "enrichmentStatus": "/api/3/picklists/a6d9da29-27b1-4b8a-965d-8d91518540d5"
-          },
-          "operation": "Overwrite",
-          "collection": "/api/3/upsert/indicators",
-          "__recommend": [],
-          "fieldOperation": {
-            "recordTags": "Overwrite"
-          },
-          "step_variables": []
-        },
-        "status": null,
-        "top": "1380",
-        "left": "475",
-        "stepType": "/api/3/workflow_step_types/2597053c-e718-44b4-8394-4d40fe26d357",
-        "group": null,
-        "uuid": "35b8cf2b-8b74-4e2b-9d20-fc0e588f5689"
-      },
-      {
-        "@type": "WorkflowStep",
-        "name": "Find Indicator",
-        "description": null,
-        "arguments": {
-          "query": {
-            "sort": [],
-            "limit": 30,
-            "logic": "AND",
-            "filters": [
+      "status": null,
+      "top": "1520",
+      "left": "480",
+      "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+      "group": null,
+      "uuid": "64a2be62-0a91-432d-9b4c-1f62adf76298"
+    },
+    {
+      "@type": "WorkflowStep",
+      "name": "Manual Input Form",
+      "description": null,
+      "arguments": {
+        "type": "InputBased",
+        "input": {
+          "schema": {
+            "title": "Create Indicator",
+            "description": "Creates an indicator with the given fields in Fortisoar.",
+            "inputVariables": [
               {
-                "type": "primitive",
-                "field": "value",
-                "value": "{{vars.indicator_val}}",
-                "operator": "eq",
-                "_operator": "eq"
+                "name": "indicator",
+                "type": "string",
+                "label": "Indicator",
+                "tooltip": "",
+                "dataType": "text",
+                "formType": "text",
+                "required": false,
+                "_expanded": true,
+                "defaultValue": null,
+                "_previousName": "",
+                "useRecordFieldDefault": false
               }
             ]
-          },
-          "module": "indicators?$limit=30",
-          "step_variables": []
-        },
-        "status": null,
-        "top": "1110",
-        "left": "650",
-        "stepType": "/api/3/workflow_step_types/b593663d-7d13-40ce-a3a3-96dece928770",
-        "group": null,
-        "uuid": "4379893f-4fb8-4fd5-80d7-650a2f5d8947"
-      },
-      {
-        "@type": "WorkflowStep",
-        "name": "Cancel",
-        "description": null,
-        "arguments": {
-          "bot_response": "\"Indicator creation cancelled!\""
-        },
-        "status": null,
-        "top": "1660",
-        "left": "1360",
-        "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-        "group": null,
-        "uuid": "4dea72b0-041c-4a88-9a66-1d35ecea99cb"
-      },
-      {
-        "@type": "WorkflowStep",
-        "name": "Extract Artifact",
-        "description": null,
-        "arguments": {
-          "name": "Utilities",
-          "params": {
-            "data": "{{vars.indicator_val}} | string",
-            "whitelist": "",
-            "case_sensitive": false,
-            "override_regex": false,
-            "private_whitelist": true
-          },
-          "version": "3.2.3",
-          "connector": "cyops_utilities",
-          "operation": "extract_artifacts",
-          "operationTitle": "FSR: Extract Artifacts from String",
-          "pickFromTenant": false,
-          "step_variables": []
-        },
-        "status": null,
-        "top": "840",
-        "left": "475",
-        "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-        "group": null,
-        "uuid": "53cdd8f7-068e-4a86-859e-1652ee2e44a3"
-      },
-      {
-        "@type": "WorkflowStep",
-        "name": "Incorrect Parameters",
-        "description": null,
-        "arguments": {
-          "bot_response": "The indicator parameters provided were incorrect"
-        },
-        "status": null,
-        "top": "1660",
-        "left": "200",
-        "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-        "group": null,
-        "uuid": "59dd8052-c04f-44b1-a365-9c526e612754"
-      },
-      {
-        "@type": "WorkflowStep",
-        "name": "Response Step",
-        "description": null,
-        "arguments": {
-          "name": "Slack",
-          "config": "633e8bd0-a5d0-48a0-addd-2bc7174b9ceb",
-          "params": {
-            "blocks": "",
-            "channel": "{%if vars.bot_context.channel_id %}{{vars.bot_context.channel_id }}{%else%}{{vars.bot_context.user_id}}{%endif%}",
-            "message": "{{vars.bot_response}}",
-            "email_id": "",
-            "thread_ts": "{{vars.bot_context.get('ts','')}}",
-            "attachments": ""
-          },
-          "version": "3.0.0",
-          "connector": "slack",
-          "operation": "send_message",
-          "operationTitle": "Send Message",
-          "pickFromTenant": false,
-          "step_variables": []
-        },
-        "status": null,
-        "top": "1650",
-        "left": "825",
-        "stepType": "/api/3/workflow_step_types/0bfed618-0316-11e7-93ae-92361f002671",
-        "group": null,
-        "uuid": "5e1e66c2-b89d-48f1-8302-f15165b84993"
-      },
-      {
-        "@type": "WorkflowStep",
-        "name": "Response",
-        "description": null,
-        "arguments": {
-          "bot_response": "Done! Indicator '<{{vars.indicator_val}}>' successfully added to the indicator list."
-        },
-        "status": null,
-        "top": "1515",
-        "left": "475",
-        "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-        "group": null,
-        "uuid": "64a2be62-0a91-432d-9b4c-1f62adf76298"
-      },
-      {
-        "@type": "WorkflowStep",
-        "name": "Manual Input Form",
-        "description": null,
-        "arguments": {
-          "type": "InputBased",
-          "input": {
-            "schema": {
-              "title": "Create Indicator",
-              "description": "Creates an indicator with the given fields in Fortisoar.",
-              "inputVariables": [
-                {
-                  "name": "indicator",
-                  "type": "string",
-                  "label": "Indicator",
-                  "tooltip": "",
-                  "dataType": "text",
-                  "formType": "text",
-                  "required": false,
-                  "_expanded": true,
-                  "defaultValue": null,
-                  "_previousName": "",
-                  "useRecordFieldDefault": false
-                }
-              ]
-            }
-          },
-          "record": "",
-          "agent_id": null,
-          "owner_detail": {
-            "isAssigned": false,
-            "emailRecipients": "",
-            "externalRecipients": "{{vars.user_id}}"
-          },
-          "isRecordLinked": false,
-          "step_variables": [],
-          "response_mapping": {
-            "options": [
-              {
-                "option": "Create Indicator",
-                "step_iri": "/api/3/workflow_steps/091bfa45-902c-4289-8813-0808f26a1ff8"
-              },
-              {
-                "option": "Cancel",
-                "step_iri": "/api/3/workflow_steps/4dea72b0-041c-4a88-9a66-1d35ecea99cb"
-              }
-            ],
-            "duplicateOption": false
-          },
-          "inputExternalUser": false,
-          "email_notification": {
-            "enabled": false,
-            "smtpParameters": []
-          },
-          "inputInternalUsers": true,
-          "inline_channel_list": [
-            "/api/3/picklists/afb18b7f-510b-471a-9b9c-7f4646edd4ee"
-          ],
-          "external_channel_list": [],
-          "unauthenticated_input": true
-        },
-        "status": null,
-        "top": "440",
-        "left": "1360",
-        "stepType": "/api/3/workflow_step_types/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
-        "group": null,
-        "uuid": "6925505d-310b-4f10-80bc-842da7046769"
-      },
-      {
-        "@type": "WorkflowStep",
-        "name": "Start",
-        "description": null,
-        "arguments": {
-          "step_variables": {
-            "input": {
-              "params": []
-            }
           }
         },
-        "status": null,
-        "top": "30",
-        "left": "825",
-        "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
-        "group": null,
-        "uuid": "978b6805-b07f-4876-b9aa-546ff464c163"
-      },
-      {
-        "@type": "WorkflowStep",
-        "name": "Temp Variable",
-        "description": null,
-        "arguments": [],
-        "status": null,
-        "top": "570",
-        "left": "475",
-        "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-        "group": null,
-        "uuid": "b89256b7-f00b-4234-bc95-e45dfdbd1896"
-      },
-      {
-        "@type": "WorkflowStep",
-        "name": "Configuration",
-        "description": null,
-        "arguments": {
-          "user_id": "{{vars.bot_context.channel_id}}",
-          "indicator_val": "{{vars.input.params.indicatorVal}}"
+        "record": "",
+        "agent_id": null,
+        "owner_detail": {
+          "isAssigned": false,
+          "emailRecipients": "",
+          "externalRecipients": "{{vars.user_id}}"
         },
-        "status": null,
-        "top": "165",
-        "left": "825",
-        "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
-        "group": null,
-        "uuid": "d64ec03a-f3d6-43c7-8859-09796e5b5a09"
-      },
-      {
-        "@type": "WorkflowStep",
-        "name": "Is indicator present",
-        "description": null,
-        "arguments": {
-          "conditions": [
+        "isRecordLinked": false,
+        "step_variables": [],
+        "response_mapping": {
+          "options": [
             {
-              "option": "Present",
-              "step_iri": "/api/3/workflow_steps/2e0879ec-e5c1-4ae2-9593-33c5df428f48",
-              "condition": "{{ (vars.steps.Find_Indicator | length) >  0 }}",
-              "step_name": "Indicator already present"
+              "option": "Create Indicator",
+              "step_iri": "/api/3/workflow_steps/091bfa45-902c-4289-8813-0808f26a1ff8"
             },
             {
-              "option": "Not Present",
-              "default": true,
-              "step_iri": "/api/3/workflow_steps/35b8cf2b-8b74-4e2b-9d20-fc0e588f5689",
-              "step_name": "Create Indicator"
+              "option": "Cancel",
+              "step_iri": "/api/3/workflow_steps/4dea72b0-041c-4a88-9a66-1d35ecea99cb"
             }
-          ]
+          ],
+          "duplicateOption": false
         },
-        "status": null,
-        "top": "1245",
-        "left": "650",
-        "stepType": "/api/3/workflow_step_types/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-        "group": null,
-        "uuid": "e5b163f6-193f-43e6-aadd-8285948dbca9"
-      },
-      {
-        "@type": "WorkflowStep",
-        "name": "Are Arguments Passed",
-        "description": null,
-        "arguments": {
-          "conditions": [
-            {
-              "option": "No",
-              "default": true,
-              "step_iri": "/api/3/workflow_steps/6925505d-310b-4f10-80bc-842da7046769",
-              "step_name": "Manual Input Form"
-            },
-            {
-              "option": "Yes",
-              "step_iri": "/api/3/workflow_steps/b89256b7-f00b-4234-bc95-e45dfdbd1896",
-              "condition": "{{ ((vars.indicator_val | string).strip() | length) > 0 }}",
-              "step_name": "Temp Variable"
-            }
-          ]
+        "inputExternalUser": false,
+        "email_notification": {
+          "enabled": false,
+          "smtpParameters": []
         },
-        "status": null,
-        "top": "300",
-        "left": "825",
-        "stepType": "/api/3/workflow_step_types/12254cf5-5db7-4b1a-8cb1-3af081924b28",
-        "group": null,
-        "uuid": "f93ddec2-3394-4095-8f4f-4bbfc2b6f372"
-      }
-    ],
-    "routes": [
-      {
-        "@type": "WorkflowRoute",
-        "name": "Manual Input Invalid Indicator -> Response Step",
-        "targetStep": "/api/3/workflow_steps/5e1e66c2-b89d-48f1-8302-f15165b84993",
-        "sourceStep": "/api/3/workflow_steps/184093ee-68a9-4f15-8afa-019e99658747",
-        "label": null,
-        "isExecuted": false,
-        "uuid": "065fe395-9f4a-4386-b7b9-94a8f3c75fd4"
+        "inputInternalUsers": true,
+        "inline_channel_list": [
+          "/api/3/picklists/afb18b7f-510b-471a-9b9c-7f4646edd4ee"
+        ],
+        "external_channel_list": [],
+        "unauthenticated_input": true
       },
-      {
-        "@type": "WorkflowRoute",
-        "name": "Cancel -> Response Step",
-        "targetStep": "/api/3/workflow_steps/5e1e66c2-b89d-48f1-8302-f15165b84993",
-        "sourceStep": "/api/3/workflow_steps/4dea72b0-041c-4a88-9a66-1d35ecea99cb",
-        "label": null,
-        "isExecuted": false,
-        "uuid": "16835c2a-0bf9-4486-93a3-0a65efa33014"
+      "status": null,
+      "top": "440",
+      "left": "1360",
+      "stepType": "/api/3/workflow_step_types/fc04082a-d7dc-4299-96fb-6837b1baa0fe",
+      "group": null,
+      "uuid": "6925505d-310b-4f10-80bc-842da7046769"
+    },
+    {
+      "@type": "WorkflowStep",
+      "name": "Start",
+      "description": null,
+      "arguments": {
+        "step_variables": {
+          "input": {
+            "params": []
+          }
+        }
       },
-      {
-        "@type": "WorkflowRoute",
-        "name": "Manual Input Form -> Set Var",
-        "targetStep": "/api/3/workflow_steps/091bfa45-902c-4289-8813-0808f26a1ff8",
-        "sourceStep": "/api/3/workflow_steps/6925505d-310b-4f10-80bc-842da7046769",
-        "label": "Create Indicator",
-        "isExecuted": false,
-        "uuid": "62e8c675-f523-4790-87bc-77a603fe9e37"
+      "status": null,
+      "top": "30",
+      "left": "825",
+      "stepType": "/api/3/workflow_step_types/b348f017-9a94-471f-87f8-ce88b6a7ad62",
+      "group": null,
+      "uuid": "978b6805-b07f-4876-b9aa-546ff464c163"
+    },
+    {
+      "@type": "WorkflowStep",
+      "name": "Temp Variable",
+      "description": null,
+      "arguments": [],
+      "status": null,
+      "top": "570",
+      "left": "475",
+      "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+      "group": null,
+      "uuid": "b89256b7-f00b-4234-bc95-e45dfdbd1896"
+    },
+    {
+      "@type": "WorkflowStep",
+      "name": "Configuration",
+      "description": null,
+      "arguments": {
+        "user_id": "{{vars.bot_context.channel_id}}",
+        "indicator_val": "{{vars.input.params.indicatorVal}}"
       },
-      {
-        "@type": "WorkflowRoute",
-        "name": "Response -> Response Step",
-        "targetStep": "/api/3/workflow_steps/5e1e66c2-b89d-48f1-8302-f15165b84993",
-        "sourceStep": "/api/3/workflow_steps/64a2be62-0a91-432d-9b4c-1f62adf76298",
-        "label": null,
-        "isExecuted": false,
-        "uuid": "76690ad0-753c-4631-885e-ba855aacd599"
+      "status": null,
+      "top": "165",
+      "left": "825",
+      "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+      "group": null,
+      "uuid": "d64ec03a-f3d6-43c7-8859-09796e5b5a09"
+    },
+    {
+      "@type": "WorkflowStep",
+      "name": "Is indicator present",
+      "description": null,
+      "arguments": {
+        "conditions": [
+          {
+            "option": "Present",
+            "step_iri": "/api/3/workflow_steps/2e0879ec-e5c1-4ae2-9593-33c5df428f48",
+            "condition": "{{ (vars.steps.Find_Indicator | length) >  0 }}",
+            "step_name": "Indicator already present"
+          },
+          {
+            "option": "Not Present",
+            "default": true,
+            "step_iri": "/api/3/workflow_steps/35b8cf2b-8b74-4e2b-9d20-fc0e588f5689",
+            "step_name": "Create Indicator"
+          }
+        ]
       },
-      {
-        "@type": "WorkflowRoute",
-        "name": "Create Indicator -> Response",
-        "targetStep": "/api/3/workflow_steps/64a2be62-0a91-432d-9b4c-1f62adf76298",
-        "sourceStep": "/api/3/workflow_steps/35b8cf2b-8b74-4e2b-9d20-fc0e588f5689",
-        "label": null,
-        "isExecuted": false,
-        "uuid": "79a6bc5e-3286-43ac-8826-3df6f40a7e20"
+      "status": null,
+      "top": "1245",
+      "left": "650",
+      "stepType": "/api/3/workflow_step_types/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+      "group": null,
+      "uuid": "e5b163f6-193f-43e6-aadd-8285948dbca9"
+    },
+    {
+      "@type": "WorkflowStep",
+      "name": "Are Arguments Passed",
+      "description": null,
+      "arguments": {
+        "conditions": [
+          {
+            "option": "No",
+            "default": true,
+            "step_iri": "/api/3/workflow_steps/6925505d-310b-4f10-80bc-842da7046769",
+            "step_name": "Manual Input Form"
+          },
+          {
+            "option": "Yes",
+            "step_iri": "/api/3/workflow_steps/b89256b7-f00b-4234-bc95-e45dfdbd1896",
+            "condition": "{{ ((vars.indicator_val | string).strip() | length) > 0 }}",
+            "step_name": "Temp Variable"
+          }
+        ]
       },
-      {
-        "@type": "WorkflowRoute",
-        "name": "Start -> Configuration",
-        "targetStep": "/api/3/workflow_steps/d64ec03a-f3d6-43c7-8859-09796e5b5a09",
-        "sourceStep": "/api/3/workflow_steps/978b6805-b07f-4876-b9aa-546ff464c163",
-        "label": null,
-        "isExecuted": false,
-        "uuid": "84ed4683-55e9-4bcf-a4c4-641eedefc526"
-      },
-      {
-        "@type": "WorkflowRoute",
-        "name": "Incorrect Parameters -> Response Step",
-        "targetStep": "/api/3/workflow_steps/5e1e66c2-b89d-48f1-8302-f15165b84993",
-        "sourceStep": "/api/3/workflow_steps/59dd8052-c04f-44b1-a365-9c526e612754",
-        "label": null,
-        "isExecuted": false,
-        "uuid": "bdfb1d04-5394-4371-a197-ebe48c69bd53"
-      },
-      {
-        "@type": "WorkflowRoute",
-        "name": "Manual Input Form -> Cancel",
-        "targetStep": "/api/3/workflow_steps/4dea72b0-041c-4a88-9a66-1d35ecea99cb",
-        "sourceStep": "/api/3/workflow_steps/6925505d-310b-4f10-80bc-842da7046769",
-        "label": "Cancel",
-        "isExecuted": false,
-        "uuid": "bf8fbb07-b218-4d95-b66d-4369c0d7441c"
-      },
-      {
-        "@type": "WorkflowRoute",
-        "name": "Check Length of Indicator -> Extract Artifact",
-        "targetStep": "/api/3/workflow_steps/53cdd8f7-068e-4a86-859e-1652ee2e44a3",
-        "sourceStep": "/api/3/workflow_steps/117e01d2-5604-4f51-b800-6affa0de51fe",
-        "label": "Params Passed",
-        "isExecuted": false,
-        "uuid": "ceb95deb-af15-4875-b02d-832698a7b59f"
-      },
-      {
-        "@type": "WorkflowRoute",
-        "name": "Indicator Validation -> No",
-        "targetStep": "/api/3/workflow_steps/59dd8052-c04f-44b1-a365-9c526e612754",
-        "sourceStep": "/api/3/workflow_steps/0e715216-3a72-444a-bfde-2f418f60d505",
-        "label": "Invalid",
-        "isExecuted": false,
-        "uuid": "d0387ac7-c642-4e48-b716-18b4a53b9c2f"
-      },
-      {
-        "@type": "WorkflowRoute",
-        "name": "Set Var -> Check Length of Indicator",
-        "targetStep": "/api/3/workflow_steps/117e01d2-5604-4f51-b800-6affa0de51fe",
-        "sourceStep": "/api/3/workflow_steps/091bfa45-902c-4289-8813-0808f26a1ff8",
-        "label": null,
-        "isExecuted": false,
-        "uuid": "e3224290-1dc6-45f0-9ed9-848fc573599d"
-      },
-      {
-        "@type": "WorkflowRoute",
-        "name": "Check Length of Indicator -> Manual Input Invalid Indicator",
-        "targetStep": "/api/3/workflow_steps/184093ee-68a9-4f15-8afa-019e99658747",
-        "sourceStep": "/api/3/workflow_steps/117e01d2-5604-4f51-b800-6affa0de51fe",
-        "label": "Params Blank",
-        "isExecuted": false,
-        "uuid": "ea458b47-b20f-4fa9-a94d-273a99c16f5e"
-      },
-      {
-        "@type": "WorkflowRoute",
-        "name": "Extract Artifact -> Is Valid Indicator",
-        "targetStep": "/api/3/workflow_steps/0e715216-3a72-444a-bfde-2f418f60d505",
-        "sourceStep": "/api/3/workflow_steps/53cdd8f7-068e-4a86-859e-1652ee2e44a3",
-        "label": null,
-        "isExecuted": false,
-        "uuid": "5eacbd1c-2be1-4bed-9f76-11a1425b9bbd"
-      },
-      {
-        "@type": "WorkflowRoute",
-        "name": "Are Parameters Passed -> Copy 1 of Set Indicator",
-        "targetStep": "/api/3/workflow_steps/b89256b7-f00b-4234-bc95-e45dfdbd1896",
-        "sourceStep": "/api/3/workflow_steps/f93ddec2-3394-4095-8f4f-4bbfc2b6f372",
-        "label": "Yes",
-        "isExecuted": false,
-        "uuid": "ceaaab5e-694d-4a0b-9946-01386abc3a06"
-      },
-      {
-        "@type": "WorkflowRoute",
-        "name": "Copy 1 of Set Indicator -> Check for blank form submission",
-        "targetStep": "/api/3/workflow_steps/117e01d2-5604-4f51-b800-6affa0de51fe",
-        "sourceStep": "/api/3/workflow_steps/b89256b7-f00b-4234-bc95-e45dfdbd1896",
-        "label": null,
-        "isExecuted": false,
-        "uuid": "52bc6762-ddbe-4319-9f9c-a554e3538cbf"
-      },
-      {
-        "@type": "WorkflowRoute",
-        "name": "Are Parameters Passed -> Manual Input Form",
-        "targetStep": "/api/3/workflow_steps/6925505d-310b-4f10-80bc-842da7046769",
-        "sourceStep": "/api/3/workflow_steps/f93ddec2-3394-4095-8f4f-4bbfc2b6f372",
-        "label": "No",
-        "isExecuted": false,
-        "uuid": "a806fd90-b3ef-4719-bd4c-99f6ce4ac688"
-      },
-      {
-        "@type": "WorkflowRoute",
-        "name": "Configuration -> Are Arguments Passed",
-        "targetStep": "/api/3/workflow_steps/f93ddec2-3394-4095-8f4f-4bbfc2b6f372",
-        "sourceStep": "/api/3/workflow_steps/d64ec03a-f3d6-43c7-8859-09796e5b5a09",
-        "label": null,
-        "isExecuted": false,
-        "uuid": "2f21db7b-0e9b-4f49-a563-eac1f5f698f3"
-      },
-      {
-        "@type": "WorkflowRoute",
-        "name": "Is Valid Indicator -> Find Indicator",
-        "targetStep": "/api/3/workflow_steps/4379893f-4fb8-4fd5-80d7-650a2f5d8947",
-        "sourceStep": "/api/3/workflow_steps/0e715216-3a72-444a-bfde-2f418f60d505",
-        "label": "Valid",
-        "isExecuted": false,
-        "uuid": "8b5ce892-55d9-490c-8b15-b75813b6415d"
-      },
-      {
-        "@type": "WorkflowRoute",
-        "name": "Find Indicator -> Is indicator present",
-        "targetStep": "/api/3/workflow_steps/e5b163f6-193f-43e6-aadd-8285948dbca9",
-        "sourceStep": "/api/3/workflow_steps/4379893f-4fb8-4fd5-80d7-650a2f5d8947",
-        "label": null,
-        "isExecuted": false,
-        "uuid": "e709bcc5-d49f-4d1d-9d8e-c5f78470a4a8"
-      },
-      {
-        "@type": "WorkflowRoute",
-        "name": "Is indicator present -> Create Indicator",
-        "targetStep": "/api/3/workflow_steps/35b8cf2b-8b74-4e2b-9d20-fc0e588f5689",
-        "sourceStep": "/api/3/workflow_steps/e5b163f6-193f-43e6-aadd-8285948dbca9",
-        "label": "Not Present",
-        "isExecuted": false,
-        "uuid": "aedbb14a-e809-42d8-8f84-81da69f62236"
-      },
-      {
-        "@type": "WorkflowRoute",
-        "name": "Is indicator present -> Indicator already present",
-        "targetStep": "/api/3/workflow_steps/2e0879ec-e5c1-4ae2-9593-33c5df428f48",
-        "sourceStep": "/api/3/workflow_steps/e5b163f6-193f-43e6-aadd-8285948dbca9",
-        "label": "Present",
-        "isExecuted": false,
-        "uuid": "3674ae5a-abdf-4210-972d-45a630bfcb2e"
-      },
-      {
-        "@type": "WorkflowRoute",
-        "name": "Indicator already present -> Response Step",
-        "targetStep": "/api/3/workflow_steps/5e1e66c2-b89d-48f1-8302-f15165b84993",
-        "sourceStep": "/api/3/workflow_steps/2e0879ec-e5c1-4ae2-9593-33c5df428f48",
-        "label": null,
-        "isExecuted": false,
-        "uuid": "bf162d60-129e-43d8-b1d8-b4812496034b"
-      }
-    ],
-    "groups": [],
-    "priority": "/api/3/picklists/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
-    "uuid": "a293b1d7-4fef-47a8-8632-cc8893e355e3",
-    "id": 476,
-    "createUser": "/api/3/people/3451141c-bac6-467c-8d72-85e0fab569ce",
-    "createDate": 1673513503.887986,
-    "modifyUser": "/api/3/people/3451141c-bac6-467c-8d72-85e0fab569ce",
-    "modifyDate": 1673534607.063189,
-    "owners": [],
-    "isPrivate": false,
-    "deletedAt": null,
-    "importedBy": [
-      {
-        "apiName": "fortiSOARForSlack",
-        "name": "FortiSOAR For Slack",
-        "version": "1.0.0"
-      }
-    ],
-    "recordTags": [
-      "bot_enabled",
-      "createIndicator"
-    ]
-  }
+      "status": null,
+      "top": "300",
+      "left": "825",
+      "stepType": "/api/3/workflow_step_types/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+      "group": null,
+      "uuid": "f93ddec2-3394-4095-8f4f-4bbfc2b6f372"
+    }
+  ],
+  "routes": [
+    {
+      "@type": "WorkflowRoute",
+      "name": "Manual Input Invalid Indicator -> Response Step",
+      "targetStep": "/api/3/workflow_steps/5e1e66c2-b89d-48f1-8302-f15165b84993",
+      "sourceStep": "/api/3/workflow_steps/184093ee-68a9-4f15-8afa-019e99658747",
+      "label": null,
+      "isExecuted": false,
+      "uuid": "065fe395-9f4a-4386-b7b9-94a8f3c75fd4"
+    },
+    {
+      "@type": "WorkflowRoute",
+      "name": "Cancel -> Response Step",
+      "targetStep": "/api/3/workflow_steps/5e1e66c2-b89d-48f1-8302-f15165b84993",
+      "sourceStep": "/api/3/workflow_steps/4dea72b0-041c-4a88-9a66-1d35ecea99cb",
+      "label": null,
+      "isExecuted": false,
+      "uuid": "16835c2a-0bf9-4486-93a3-0a65efa33014"
+    },
+    {
+      "@type": "WorkflowRoute",
+      "name": "Manual Input Form -> Set Var",
+      "targetStep": "/api/3/workflow_steps/091bfa45-902c-4289-8813-0808f26a1ff8",
+      "sourceStep": "/api/3/workflow_steps/6925505d-310b-4f10-80bc-842da7046769",
+      "label": "Create Indicator",
+      "isExecuted": false,
+      "uuid": "62e8c675-f523-4790-87bc-77a603fe9e37"
+    },
+    {
+      "@type": "WorkflowRoute",
+      "name": "Response -> Response Step",
+      "targetStep": "/api/3/workflow_steps/5e1e66c2-b89d-48f1-8302-f15165b84993",
+      "sourceStep": "/api/3/workflow_steps/64a2be62-0a91-432d-9b4c-1f62adf76298",
+      "label": null,
+      "isExecuted": false,
+      "uuid": "76690ad0-753c-4631-885e-ba855aacd599"
+    },
+    {
+      "@type": "WorkflowRoute",
+      "name": "Create Indicator -> Response",
+      "targetStep": "/api/3/workflow_steps/64a2be62-0a91-432d-9b4c-1f62adf76298",
+      "sourceStep": "/api/3/workflow_steps/35b8cf2b-8b74-4e2b-9d20-fc0e588f5689",
+      "label": null,
+      "isExecuted": false,
+      "uuid": "79a6bc5e-3286-43ac-8826-3df6f40a7e20"
+    },
+    {
+      "@type": "WorkflowRoute",
+      "name": "Start -> Configuration",
+      "targetStep": "/api/3/workflow_steps/d64ec03a-f3d6-43c7-8859-09796e5b5a09",
+      "sourceStep": "/api/3/workflow_steps/978b6805-b07f-4876-b9aa-546ff464c163",
+      "label": null,
+      "isExecuted": false,
+      "uuid": "84ed4683-55e9-4bcf-a4c4-641eedefc526"
+    },
+    {
+      "@type": "WorkflowRoute",
+      "name": "Incorrect Parameters -> Response Step",
+      "targetStep": "/api/3/workflow_steps/5e1e66c2-b89d-48f1-8302-f15165b84993",
+      "sourceStep": "/api/3/workflow_steps/59dd8052-c04f-44b1-a365-9c526e612754",
+      "label": null,
+      "isExecuted": false,
+      "uuid": "bdfb1d04-5394-4371-a197-ebe48c69bd53"
+    },
+    {
+      "@type": "WorkflowRoute",
+      "name": "Manual Input Form -> Cancel",
+      "targetStep": "/api/3/workflow_steps/4dea72b0-041c-4a88-9a66-1d35ecea99cb",
+      "sourceStep": "/api/3/workflow_steps/6925505d-310b-4f10-80bc-842da7046769",
+      "label": "Cancel",
+      "isExecuted": false,
+      "uuid": "bf8fbb07-b218-4d95-b66d-4369c0d7441c"
+    },
+    {
+      "@type": "WorkflowRoute",
+      "name": "Check Length of Indicator -> Extract Artifact",
+      "targetStep": "/api/3/workflow_steps/53cdd8f7-068e-4a86-859e-1652ee2e44a3",
+      "sourceStep": "/api/3/workflow_steps/117e01d2-5604-4f51-b800-6affa0de51fe",
+      "label": "Params Passed",
+      "isExecuted": false,
+      "uuid": "ceb95deb-af15-4875-b02d-832698a7b59f"
+    },
+    {
+      "@type": "WorkflowRoute",
+      "name": "Indicator Validation -> No",
+      "targetStep": "/api/3/workflow_steps/59dd8052-c04f-44b1-a365-9c526e612754",
+      "sourceStep": "/api/3/workflow_steps/0e715216-3a72-444a-bfde-2f418f60d505",
+      "label": "Invalid",
+      "isExecuted": false,
+      "uuid": "d0387ac7-c642-4e48-b716-18b4a53b9c2f"
+    },
+    {
+      "@type": "WorkflowRoute",
+      "name": "Set Var -> Check Length of Indicator",
+      "targetStep": "/api/3/workflow_steps/117e01d2-5604-4f51-b800-6affa0de51fe",
+      "sourceStep": "/api/3/workflow_steps/091bfa45-902c-4289-8813-0808f26a1ff8",
+      "label": null,
+      "isExecuted": false,
+      "uuid": "e3224290-1dc6-45f0-9ed9-848fc573599d"
+    },
+    {
+      "@type": "WorkflowRoute",
+      "name": "Check Length of Indicator -> Manual Input Invalid Indicator",
+      "targetStep": "/api/3/workflow_steps/184093ee-68a9-4f15-8afa-019e99658747",
+      "sourceStep": "/api/3/workflow_steps/117e01d2-5604-4f51-b800-6affa0de51fe",
+      "label": "Params Blank",
+      "isExecuted": false,
+      "uuid": "ea458b47-b20f-4fa9-a94d-273a99c16f5e"
+    },
+    {
+      "@type": "WorkflowRoute",
+      "name": "Extract Artifact -> Is Valid Indicator",
+      "targetStep": "/api/3/workflow_steps/0e715216-3a72-444a-bfde-2f418f60d505",
+      "sourceStep": "/api/3/workflow_steps/53cdd8f7-068e-4a86-859e-1652ee2e44a3",
+      "label": null,
+      "isExecuted": false,
+      "uuid": "5eacbd1c-2be1-4bed-9f76-11a1425b9bbd"
+    },
+    {
+      "@type": "WorkflowRoute",
+      "name": "Are Parameters Passed -> Copy 1 of Set Indicator",
+      "targetStep": "/api/3/workflow_steps/b89256b7-f00b-4234-bc95-e45dfdbd1896",
+      "sourceStep": "/api/3/workflow_steps/f93ddec2-3394-4095-8f4f-4bbfc2b6f372",
+      "label": "Yes",
+      "isExecuted": false,
+      "uuid": "ceaaab5e-694d-4a0b-9946-01386abc3a06"
+    },
+    {
+      "@type": "WorkflowRoute",
+      "name": "Copy 1 of Set Indicator -> Check for blank form submission",
+      "targetStep": "/api/3/workflow_steps/117e01d2-5604-4f51-b800-6affa0de51fe",
+      "sourceStep": "/api/3/workflow_steps/b89256b7-f00b-4234-bc95-e45dfdbd1896",
+      "label": null,
+      "isExecuted": false,
+      "uuid": "52bc6762-ddbe-4319-9f9c-a554e3538cbf"
+    },
+    {
+      "@type": "WorkflowRoute",
+      "name": "Are Parameters Passed -> Manual Input Form",
+      "targetStep": "/api/3/workflow_steps/6925505d-310b-4f10-80bc-842da7046769",
+      "sourceStep": "/api/3/workflow_steps/f93ddec2-3394-4095-8f4f-4bbfc2b6f372",
+      "label": "No",
+      "isExecuted": false,
+      "uuid": "a806fd90-b3ef-4719-bd4c-99f6ce4ac688"
+    },
+    {
+      "@type": "WorkflowRoute",
+      "name": "Configuration -> Are Arguments Passed",
+      "targetStep": "/api/3/workflow_steps/f93ddec2-3394-4095-8f4f-4bbfc2b6f372",
+      "sourceStep": "/api/3/workflow_steps/d64ec03a-f3d6-43c7-8859-09796e5b5a09",
+      "label": null,
+      "isExecuted": false,
+      "uuid": "2f21db7b-0e9b-4f49-a563-eac1f5f698f3"
+    },
+    {
+      "@type": "WorkflowRoute",
+      "name": "Is Valid Indicator -> Find Indicator",
+      "targetStep": "/api/3/workflow_steps/4379893f-4fb8-4fd5-80d7-650a2f5d8947",
+      "sourceStep": "/api/3/workflow_steps/0e715216-3a72-444a-bfde-2f418f60d505",
+      "label": "Valid",
+      "isExecuted": false,
+      "uuid": "8b5ce892-55d9-490c-8b15-b75813b6415d"
+    },
+    {
+      "@type": "WorkflowRoute",
+      "name": "Find Indicator -> Is indicator present",
+      "targetStep": "/api/3/workflow_steps/e5b163f6-193f-43e6-aadd-8285948dbca9",
+      "sourceStep": "/api/3/workflow_steps/4379893f-4fb8-4fd5-80d7-650a2f5d8947",
+      "label": null,
+      "isExecuted": false,
+      "uuid": "e709bcc5-d49f-4d1d-9d8e-c5f78470a4a8"
+    },
+    {
+      "@type": "WorkflowRoute",
+      "name": "Is indicator present -> Create Indicator",
+      "targetStep": "/api/3/workflow_steps/35b8cf2b-8b74-4e2b-9d20-fc0e588f5689",
+      "sourceStep": "/api/3/workflow_steps/e5b163f6-193f-43e6-aadd-8285948dbca9",
+      "label": "Not Present",
+      "isExecuted": false,
+      "uuid": "aedbb14a-e809-42d8-8f84-81da69f62236"
+    },
+    {
+      "@type": "WorkflowRoute",
+      "name": "Is indicator present -> Indicator already present",
+      "targetStep": "/api/3/workflow_steps/2e0879ec-e5c1-4ae2-9593-33c5df428f48",
+      "sourceStep": "/api/3/workflow_steps/e5b163f6-193f-43e6-aadd-8285948dbca9",
+      "label": "Present",
+      "isExecuted": false,
+      "uuid": "3674ae5a-abdf-4210-972d-45a630bfcb2e"
+    },
+    {
+      "@type": "WorkflowRoute",
+      "name": "Indicator already present -> Response Step",
+      "targetStep": "/api/3/workflow_steps/5e1e66c2-b89d-48f1-8302-f15165b84993",
+      "sourceStep": "/api/3/workflow_steps/2e0879ec-e5c1-4ae2-9593-33c5df428f48",
+      "label": null,
+      "isExecuted": false,
+      "uuid": "bf162d60-129e-43d8-b1d8-b4812496034b"
+    }
+  ],
+  "groups": [],
+  "priority": "/api/3/picklists/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
+  "uuid": "a293b1d7-4fef-47a8-8632-cc8893e355e3",
+  "id": 476,
+  "owners": [],
+  "isPrivate": false,
+  "deletedAt": null,
+  "importedBy": [
+    {
+      "apiName": "fortiSOARForSlack",
+      "name": "FortiSOAR For Slack",
+      "version": "1.0.0"
+    }
+  ],
+  "recordTags": [
+    "bot_enabled",
+    "createIndicator"
+  ]
+}

--- a/playbooks/02 - Use Case - FortiSOAR for Slack/Create Indicator.json
+++ b/playbooks/02 - Use Case - FortiSOAR for Slack/Create Indicator.json
@@ -13,7 +13,7 @@
     "indicatorVal"
   ],
   "synchronous": false,
-  "lastModifyDate": 1673935758,
+  "lastModifyDate": 1673940441,
   "collection": "/api/3/workflow_collections/49291f43-e8a1-4f63-80b5-d88e05044a4a",
   "versions": [],
   "triggerStep": "/api/3/workflow_steps/978b6805-b07f-4876-b9aa-546ff464c163",
@@ -91,11 +91,11 @@
       "name": "Manual Input Invalid Indicator",
       "description": null,
       "arguments": {
-        "bot_response": "[\n\t\t{\n\t\t\t\"type\": \"section\",\n\t\t\t\"text\": {\n\t\t\t\t\"type\": \"plain_text\",\n\t\t\t\t\"text\": \"The indicator parameters provided were incorrect.\"\n\t\t\t}\n\t\t}\n\t]"
+        "bot_response": "[\n  {\n    \"type\": \"section\",\n    \"text\": {\n      \"type\": \"plain_text\",\n      \"text\": \"Blank form submitted.\"\n    }\n  }\n]"
       },
       "status": null,
-      "top": "1515",
-      "left": "1175",
+      "top": "1420",
+      "left": "1160",
       "stepType": "/api/3/workflow_step_types/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
       "group": null,
       "uuid": "184093ee-68a9-4f15-8afa-019e99658747"
@@ -105,7 +105,7 @@
       "name": "Indicator already present",
       "description": null,
       "arguments": {
-        "bot_response": "[\n\t\t{\n\t\t\t\"type\": \"section\",\n\t\t\t\"text\": {\n\t\t\t\t\"type\": \"plain_text\",\n\t\t\t\t\"text\": \"Indicator already present!\"\n\t\t\t}\n\t\t}\n\t]"
+        "bot_response": "[\n  {\n    \"type\": \"section\",\n    \"text\": {\n      \"type\": \"plain_text\",\n      \"text\": \"Indicator already present!\"\n    }\n  }\n]"
       },
       "status": null,
       "top": "1515",
@@ -183,7 +183,7 @@
       "name": "Cancel",
       "description": null,
       "arguments": {
-        "bot_response": "[\n\t\t{\n\t\t\t\"type\": \"section\",\n\t\t\t\"text\": {\n\t\t\t\t\"type\": \"plain_text\",\n\t\t\t\t\"text\": \"Indicator creation cancelled!\"\n\t\t\t}\n\t\t}\n\t]"
+        "bot_response": "[\n  {\n    \"type\": \"section\",\n    \"text\": {\n      \"type\": \"plain_text\",\n      \"text\": \"Indicator creation cancelled!\"\n    }\n  }\n]"
       },
       "status": null,
       "top": "1660",
@@ -224,7 +224,7 @@
       "name": "Incorrect Parameters",
       "description": null,
       "arguments": {
-        "bot_response": "[\n\t\t{\n\t\t\t\"type\": \"section\",\n\t\t\t\"text\": {\n\t\t\t\t\"type\": \"plain_text\",\n\t\t\t\t\"text\": \"The indicator parameters provided were incorrect.\"\n\t\t\t}\n\t\t}\n\t]"
+        "bot_response": "[\n  {\n    \"type\": \"section\",\n    \"text\": {\n      \"type\": \"plain_text\",\n      \"text\": \"The indicator parameters provided were incorrect.\"\n    }\n  }\n]"
       },
       "status": null,
       "top": "1660",
@@ -267,7 +267,7 @@
       "name": "Response",
       "description": null,
       "arguments": {
-        "bot_response": "[\n\t\t{\n\t\t\t\"type\": \"section\",\n\t\t\t\"text\": {\n\t\t\t\t\"type\": \"plain_text\",\n\t\t\t\t\"text\": \"Done! Indicator '{{vars.indicator_val}}' successfully added to the indicator list.\"\n\t\t\t}\n\t\t}\n\t]"
+        "bot_response": "[\n  {\n    \"type\": \"section\",\n    \"text\": {\n      \"type\": \"plain_text\",\n      \"text\": \"Done! Indicator '{{vars.indicator_val}}' successfully added to the indicator list.\"\n    }\n  }\n]"
       },
       "status": null,
       "top": "1520",
@@ -399,7 +399,7 @@
             "option": "Present",
             "step_iri": "/api/3/workflow_steps/2e0879ec-e5c1-4ae2-9593-33c5df428f48",
             "condition": "{{ (vars.steps.Find_Indicator | length) >  0 }}",
-            "step_name": "Indicator already present"
+            "step_name": "Indicator already presemt"
           },
           {
             "option": "Not Present",
@@ -627,7 +627,7 @@
     },
     {
       "@type": "WorkflowRoute",
-      "name": "Is indicator present -> Indicator already present",
+      "name": "Is indicator present -> Indicator already presemt",
       "targetStep": "/api/3/workflow_steps/2e0879ec-e5c1-4ae2-9593-33c5df428f48",
       "sourceStep": "/api/3/workflow_steps/e5b163f6-193f-43e6-aadd-8285948dbca9",
       "label": "Present",
@@ -636,7 +636,7 @@
     },
     {
       "@type": "WorkflowRoute",
-      "name": "Indicator already present -> Response Step",
+      "name": "Indicator already presemt -> Response Step",
       "targetStep": "/api/3/workflow_steps/5e1e66c2-b89d-48f1-8302-f15165b84993",
       "sourceStep": "/api/3/workflow_steps/2e0879ec-e5c1-4ae2-9593-33c5df428f48",
       "label": null,
@@ -648,6 +648,10 @@
   "priority": "/api/3/picklists/2b563c61-ae2c-41c0-a85a-c9709585e3f2",
   "uuid": "a293b1d7-4fef-47a8-8632-cc8893e355e3",
   "id": 476,
+  "createUser": "/api/3/people/3451141c-bac6-467c-8d72-85e0fab569ce",
+  "createDate": 1673513503.887986,
+  "modifyUser": "/api/3/people/3451141c-bac6-467c-8d72-85e0fab569ce",
+  "modifyDate": 1673940488.783295,
   "owners": [],
   "isPrivate": false,
   "deletedAt": null,


### PR DESCRIPTION
#### Descriptions:
Changes in the Indicator playbook to remove '<>' from indicator value and make link non clickable

#### Fix:
Changed the output format to block

UTC:
Command- /fortisoar createIndicator
The message is displayed as expected for all the cases :
1. Input form submitted blank
2. Ip sent as an indicator 4. url sent as an indicator
5. clicked on cancel button

